### PR TITLE
Add Default Clang Build Job to GitHub Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,56 @@
 #    integration configuration file for connman.
 #
 
+---
+
 name: "Build"
 
 on: [push, pull_request]
 
 jobs:
+
+  clang:
+    name: "clang/LLVM ${{matrix.configuration['name']}} w/ ${{matrix.firewall['name']}} Firewall"
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        configuration:
+          - { name: "Debug",   options: "--enable-debug --disable-optimization" }
+          - { name: "Release", options: "--disable-debug" }
+        firewall:
+          - { name: "IP Tables", type: "iptables", packages: "libxtables-dev" }
+          - { name: "NF Tables", type: "nftables", packages: "libnftables-dev libnftnl-dev" }
+    env:
+      CC: clang
+    steps:
+
+      - name: "Install Job Package Dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get --no-install-recommends install -y clang
+
+      - name: "Install connman Package Dependencies"
+        run: |
+          sudo apt-get -y install autoconf automake libtool libdbus-1-dev libglib2.0-dev libgnutls28-dev libmnl-dev libopenconnect-dev libreadline-dev openconnect openvpn ppp-dev vpnc ${{matrix.firewall['packages']}}
+
+      - name: "Checkout"
+        uses: actions/checkout@v3.5.3
+
+      - name: "Bootstrap and Configure"
+        run: |
+          ./bootstrap-configure -C ${{matrix.configuration['options']}} --with-firewall=${{matrix.firewall['type']}}
+
+      - name: "Build"
+        run: |
+          make -j
+
+      - name: "Test"
+        run: |
+          make -j check
+
+      - name: "Distribution"
+        run: |
+          make -j dist
 
   gcc:
     name: "GCC ${{matrix.configuration['name']}} w/ ${{matrix.firewall['name']}} Firewall"
@@ -35,37 +80,39 @@ jobs:
     strategy:
       matrix:
         configuration:
-	  - { name: "Debug",   options: "--enable-debug --disable-optimization" }
-	  - { name: "Release", options: "--disable-debug" }
-	firewall:
-	  - { name: "IP Tables", type: "iptables", packages: "libxtables-dev" }
-	  - { name: "NF Tables", type: "nftables", packages: "libmnl-dev libnftables-dev" }
+          - { name: "Debug",   options: "--enable-debug --disable-optimization" }
+          - { name: "Release", options: "--disable-debug" }
+        firewall:
+          - { name: "IP Tables", type: "iptables", packages: "libxtables-dev" }
+          - { name: "NF Tables", type: "nftables", packages: "libnftables-dev libnftnl-dev" }
+    env:
+      CC: gcc
     steps:
 
-    - name: "Install Job Package Dependencies"
-      run: |
-        sudo apt-get update
-        sudo apt-get --no-install-recommends install -y gcc
+      - name: "Install Job Package Dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get --no-install-recommends install -y gcc
 
-    - name: "Install connman Package Dependencies"
-      run: |
-        sudo apt-get -y install autoconf automake libtool libdbus-1-dev libglib2.0-dev libgnutls28-dev libreadline-dev ppp-dev ${{matrix.firewall['packages']}}
+      - name: "Install connman Package Dependencies"
+        run: |
+          sudo apt-get -y install autoconf automake libtool libdbus-1-dev libglib2.0-dev libgnutls28-dev libmnl-dev libopenconnect-dev libreadline-dev openconnect openvpn ppp-dev vpnc ${{matrix.firewall['packages']}}
 
-    - name: "Checkout"
-      uses: actions/checkout@v3.5.3
+      - name: "Checkout"
+        uses: actions/checkout@v3.5.3
 
-    - name: "Bootstrap and Configure"
-      run: |
-        ./bootstrap-configure -C ${{matrix.configuration['options']}} --with-firewall=${{matrix.firewall['type']}}
+      - name: "Bootstrap and Configure"
+        run: |
+          ./bootstrap-configure -C ${{matrix.configuration['options']}} --with-firewall=${{matrix.firewall['type']}}
 
-    - name: "Build"
-      run: |
-        make -j
+      - name: "Build"
+        run: |
+          make -j
 
-    - name: "Test"
-      run: |
-        make -j check
+      - name: "Test"
+        run: |
+          make -j check
 
-    - name: "Distribution"
-      run: |
-        make -j dist
+      - name: "Distribution"
+        run: |
+          make -j dist


### PR DESCRIPTION
This adds a clang default version build job to GitHub Actions continuous integration.