### PR TITLE
Allow Running bootstrap-configure from Anywhere

### DIFF
--- a/bootstrap-configure
+++ b/bootstrap-configure
@@ -1,11 +1,13 @@
 #!/bin/sh
 
+ourdir=$(cd $(dirname "${0}") && pwd)
+
 if [ -f config.status ]; then
 	make maintainer-clean
 fi
 
-./bootstrap && \
-    ./configure --enable-maintainer-mode \
+(cd "${ourdir}" && ./bootstrap) && \
+    "${ourdir}/configure" --enable-maintainer-mode \
 		--enable-debug \
 		--prefix=/usr \
 		--mandir=/usr/share/man \


### PR DESCRIPTION
Frequently it is valuable to do non-colocated source and build directories. This updates `bootstrap-configure` such that it may be run in any arbitrary directory such that builds so bootstrapped and configured may be non-colocated.