### PR TITLE
resolver: FIX path to resolv.conf config option

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -599,6 +599,8 @@ static void parse_config(GKeyFile *config)
 	if (!error)
 		connman_settings.regdom_follows_timezone = boolean;
 
+	g_clear_error(&error);
+
 	string = __connman_config_get_string(config, "General",
 				CONF_RESOLV_CONF, &error);
 	if (!error)
@@ -801,6 +803,9 @@ char *connman_setting_get_string(const char *key)
 		return connman_settings.localtime ?
 			connman_settings.localtime : DEFAULT_LOCALTIME;
 
+	if (g_str_equal(key, CONF_RESOLV_CONF))
+		return connman_settings.resolv_conf;
+
 	return NULL;
 }
 
@@ -841,9 +846,6 @@ bool connman_setting_get_bool(const char *key)
 
 	if (g_str_equal(key, CONF_REGDOM_FOLLOWS_TIMEZONE))
 		return connman_settings.regdom_follows_timezone;
-
-	if (g_str_equal(key, CONF_RESOLV_CONF))
-		return connman_settings.resolv_conf;
 
 	return false;
 }


### PR DESCRIPTION
This addresses #4 with an upstream [patch applied from the connman community](https://lore.kernel.org/connman/344155DA-16CE-4CC8-847E-CA3EBB00A664@nuovations.com/T/#t) from [Nicolas Gariepy](mailto:ngariepy1999@gmail.com):

1. There are two problems with how the `ResolvConf` option was implemented:
    1. The `ResolvConf` is used in _src/resolver.c_ using the function `connman_setting_get_string` but the `connman_settings.resolv_conf` option could only be accessed using the `connman_setting_get_bool` function. The latter returns `bool` type where as the former returns the desired `const char *` type.
    2. The GLib `GError` is not cleared before trying to read the `ResolvConf` parameter, resulting in the following error on standard out not otherwise seen in logs:

```
(connmand:508): GLib-WARNING **: 18:03:18.861: GError set over the top of a previous GError or uninitialized memory.
This indicates a bug in someone's code. You must ensure an error is NULL before it's set.
The overwriting error message was: Key file does not have key "ResolvConf" in group "General"
```