### PR TITLE
Return the '<null>' String if the Service is Null from 'connman_service_get_identifier'

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -7296,7 +7296,7 @@ struct connman_service *__connman_service_lookup_from_index(int index)
 
 const char *connman_service_get_identifier(struct connman_service *service)
 {
-	return service ? service->identifier : NULL;
+	return service ? service->identifier : "<null>";
 }
 
 const char *__connman_service_get_path(struct connman_service *service)


### PR DESCRIPTION
This returns the `<null>` string from `connman_service_get_identifer` if the service is null. Unfortunately, not all versions of all C Standard Libraries on all platforms cope well with a literal null and the `%s` format specifier.