### PR TITLE
Be Consistent about Debug Logging Service and IP Config Type

### DIFF
--- a/src/proxy.c
+++ b/src/proxy.c
@@ -107,7 +107,9 @@ unsigned int connman_proxy_lookup(const char *interface, const char *url,
 {
 	struct proxy_lookup *lookup;
 
-	DBG("interface %s url %s", interface, url);
+	DBG("interface %s url %s service %p (%s)",
+		interface, url,
+		service, connman_service_get_identifier(service));
 
 	if (!interface)
 		return 0;

--- a/src/service.c
+++ b/src/service.c
@@ -3612,7 +3612,10 @@ int __connman_service_reset_ipconfig(struct connman_service *service,
 void __connman_service_wispr_start(struct connman_service *service,
 					enum connman_ipconfig_type type)
 {
-	DBG("service %p type %s", service, __connman_ipconfig_type2string(type));
+	DBG("service %p (%s) type %d (%s)",
+		service,
+		connman_service_get_identifier(service),
+		type, __connman_ipconfig_type2string(type));
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
 		service->online_check_interval_ipv4 =
@@ -4720,8 +4723,11 @@ static void downgrade_state(struct connman_service *service)
 	if (!service)
 		return;
 
-	DBG("service %p state4 %d state6 %d", service, service->state_ipv4,
-						service->state_ipv6);
+	DBG("service %p (%s) state4 %d (%s) state6 %d (%s)",
+		service,
+		connman_service_get_identifier(service),
+		service->state_ipv4, state2string(service->state_ipv4),
+		service->state_ipv6, state2string(service->state_ipv6));
 
 	if (service->state_ipv4 == CONNMAN_SERVICE_STATE_ONLINE)
 		__connman_service_ipconfig_indicate_state(service,
@@ -6005,8 +6011,9 @@ static int service_indicate_state(struct connman_service *service)
 	old_state = service->state;
 	new_state = combine_state(service->state_ipv4, service->state_ipv6);
 
-	DBG("service %p old %s - new %s/%s => %s",
+	DBG("service %p (%s) old %s - new %s/%s => %s",
 					service,
+					connman_service_get_identifier(service),
 					state2string(old_state),
 					state2string(service->state_ipv4),
 					state2string(service->state_ipv6),
@@ -6382,8 +6389,11 @@ void __connman_service_online_check(struct connman_service *service,
 	enum connman_service_state current_state;
 	int timeout;
 
-	DBG("service %p type %s success %d\n",
-		service, __connman_ipconfig_type2string(type), success);
+	DBG("service %p (%s) type %d (%s) success %d\n",
+		service,
+		connman_service_get_identifier(service),
+		type, __connman_ipconfig_type2string(type),
+		success);
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4) {
 		interval = &service->online_check_interval_ipv4;
@@ -6409,8 +6419,9 @@ void __connman_service_online_check(struct connman_service *service,
 	}
 
 redo_func:
-	DBG("service %p type %s interval %d", service,
-		__connman_ipconfig_type2string(type), *interval);
+	DBG("service %p (%s) type %d (%s) interval %d", service,
+		connman_service_get_identifier(service),
+		type, __connman_ipconfig_type2string(type), *interval);
 
 	timeout = g_timeout_add_seconds(*interval * *interval,
 				redo_func, connman_service_ref(service));

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -921,8 +921,11 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
 	int err = 0;
 	int i;
 
-	DBG("wispr/portal context %p service %p", wp_context,
-		wp_context->service);
+	DBG("wispr/portal context %p service %p (%s) type %d (%s)",
+		wp_context,
+		wp_context->service,
+		connman_service_get_identifier(wp_context->service),
+		wp_context->type, __connman_ipconfig_type2string(wp_context->type));
 
 	interface = connman_service_get_interface(wp_context->service);
 	if (!interface)
@@ -995,8 +998,9 @@ int __connman_wispr_start(struct connman_service *service,
 	struct connman_wispr_portal *wispr_portal = NULL;
 	int index, err;
 
-	DBG("service %p %s", service,
-		__connman_ipconfig_type2string(type));
+	DBG("service %p (%s) type %d (%s)",
+		service, connman_service_get_identifier(service),
+		type, __connman_ipconfig_type2string(type));
 
 	if (!wispr_portal_hash)
 		return -EINVAL;
@@ -1070,7 +1074,7 @@ void __connman_wispr_stop(struct connman_service *service)
 	struct connman_wispr_portal *wispr_portal;
 	int index;
 
-	DBG("service %p", service);
+	DBG("service %p (%s)", service, connman_service_get_identifier(service));
 
 	if (!wispr_portal_hash)
 		return;

--- a/src/wpad.c
+++ b/src/wpad.c
@@ -131,7 +131,7 @@ int __connman_wpad_start(struct connman_service *service)
 	int index;
 	int i;
 
-	DBG("service %p", service);
+	DBG("service %p (%s)", service, connman_service_get_identifier(service));
 
 	if (!wpad_list)
 		return -EINVAL;


### PR DESCRIPTION
In a number of `DBG` log instances, there are inconsistencies in what and how a service and its IP configuration type are logged. In some places, it is just pointers and enumeration values. In other places, it is pointers, identifiers, and strings without enumerated values.

This makes several such instances consistent, logging the service pointer, the service instance name, the IP configuration type enumerated value and its string equivalent.