### PR TITLE
Const-qualify 'connman_ipconfig_get_index'

### DIFF
--- a/src/connman.h
+++ b/src/connman.h
@@ -334,7 +334,7 @@ void __connman_ipconfig_unref_debug(struct connman_ipconfig *ipconfig,
 void *__connman_ipconfig_get_data(struct connman_ipconfig *ipconfig);
 void __connman_ipconfig_set_data(struct connman_ipconfig *ipconfig, void *data);
 
-int __connman_ipconfig_get_index(struct connman_ipconfig *ipconfig);
+int __connman_ipconfig_get_index(const struct connman_ipconfig *ipconfig);
 
 void __connman_ipconfig_set_ops(struct connman_ipconfig *ipconfig,
 				const struct connman_ipconfig_ops *ops);

--- a/src/ipconfig.c
+++ b/src/ipconfig.c
@@ -1388,7 +1388,7 @@ void __connman_ipconfig_set_data(struct connman_ipconfig *ipconfig, void *data)
  *
  * Get interface index
  */
-int __connman_ipconfig_get_index(struct connman_ipconfig *ipconfig)
+int __connman_ipconfig_get_index(const struct connman_ipconfig *ipconfig)
 {
 	if (!ipconfig)
 		return -1;


### PR DESCRIPTION
Const-qualify the network service argument of `connman_ipconfig_get_index` to make it clear to the compiler, static analyzers, and human readers that the function is strictly a getter with no network mutation side effects.