### PR TITLE
Const-qualify 'connman_{network,provider}_get_index'.

### DIFF
--- a/include/network.h
+++ b/include/network.h
@@ -85,7 +85,7 @@ enum connman_network_type connman_network_get_type(struct connman_network *netwo
 const char *connman_network_get_identifier(struct connman_network *network);
 
 void connman_network_set_index(struct connman_network *network, int index);
-int connman_network_get_index(struct connman_network *network);
+int connman_network_get_index(const struct connman_network *network);
 
 void connman_network_set_group(struct connman_network *network,
 						const char *group);

--- a/include/provider.h
+++ b/include/provider.h
@@ -94,7 +94,7 @@ int connman_provider_indicate_error(struct connman_provider *provider,
 					enum connman_provider_error error);
 
 void connman_provider_set_index(struct connman_provider *provider, int index);
-int connman_provider_get_index(struct connman_provider *provider);
+int connman_provider_get_index(const struct connman_provider *provider);
 
 void connman_provider_set_data(struct connman_provider *provider, void *data);
 void *connman_provider_get_data(struct connman_provider *provider);

--- a/src/network.c
+++ b/src/network.c
@@ -1404,7 +1404,7 @@ done:
  *
  * Get index number of network
  */
-int connman_network_get_index(struct connman_network *network)
+int connman_network_get_index(const struct connman_network *network)
 {
 	return network->index;
 }

--- a/src/provider.c
+++ b/src/provider.c
@@ -535,7 +535,7 @@ done:
 	provider->index = index;
 }
 
-int connman_provider_get_index(struct connman_provider *provider)
+int connman_provider_get_index(const struct connman_provider *provider)
 {
 	return provider->index;
 }


### PR DESCRIPTION
Const-qualify the network and provider arguments of `'connman_{network,provider}_get_index'` to make it clear to the compiler, static analyzers, and human readers that the function is strictly a getter with no network or provider mutation side effects.