### PR TITLE
Fix Heap-use-after-free Fault in 'connman_service_get_nameservers' on Service Removal

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -6538,11 +6538,12 @@ int __connman_service_ipconfig_indicate_state(struct connman_service *service,
 	else
 		service->state_ipv6 = new_state;
 
-	if (!is_connected(old_state) && is_connected(new_state))
+	if (!is_connected(old_state) && is_connected(new_state)) {
 		nameserver_add_all(service, type);
 
-	__connman_timeserver_sync(service,
-				CONNMAN_TIMESERVER_SYNC_REASON_STATE_UPDATE);
+		__connman_timeserver_sync(service,
+					CONNMAN_TIMESERVER_SYNC_REASON_STATE_UPDATE);
+    }
 
 	return service_indicate_state(service);
 }

--- a/src/service.c
+++ b/src/service.c
@@ -5088,7 +5088,7 @@ static void service_free(gpointer user_data)
 	struct connman_service *service = user_data;
 	char *path = service->path;
 
-	DBG("service %p", service);
+	DBG("service %p (%s)", service, connman_service_get_identifier(service));
 
 	reply_pending(service, ENOENT);
 

--- a/src/timeserver.c
+++ b/src/timeserver.c
@@ -395,6 +395,8 @@ static void ts_set_nameservers(struct connman_service *service)
 
 static void ts_reset(struct connman_service *service)
 {
+	DBG("service %p", service);
+
 	if (!resolv)
 		return;
 
@@ -431,9 +433,30 @@ static void ts_reset(struct connman_service *service)
 	timeserver_sync_start();
 }
 
+static const char * timeserver_sync_reason2string(
+			enum connman_timeserver_sync_reason reason)
+{
+	switch (reason) {
+	case CONNMAN_TIMESERVER_SYNC_REASON_START:
+        return "start";
+	case CONNMAN_TIMESERVER_SYNC_REASON_ADDRESS_UPDATE:
+        return "address update";
+	case CONNMAN_TIMESERVER_SYNC_REASON_STATE_UPDATE:
+        return "state update";
+	case CONNMAN_TIMESERVER_SYNC_REASON_TS_CHANGE:
+        return "timeserver change";
+	}
+
+    return "unknown";
+}
+
 void __connman_timeserver_sync(struct connman_service *service,
 			enum connman_timeserver_sync_reason reason)
 {
+	DBG("service %p (%s) reason %d (%s)",
+		service, connman_service_get_identifier(service),
+		reason, timeserver_sync_reason2string(reason));
+
 	if (!service)
 		return;
 

--- a/src/timeserver.c
+++ b/src/timeserver.c
@@ -35,6 +35,11 @@
 
 #define TS_RECHECK_INTERVAL     7200
 
+/**
+ *  A strong (that is, uses #connman_service_{ref,unref}) reference to
+ *  the network service currently used for time of day sychronization.
+ *
+ */
 static struct connman_service *ts_service;
 static GSList *timeservers_list = NULL;
 static GSList *ts_list = NULL;
@@ -429,7 +434,16 @@ static void ts_reset(struct connman_service *service)
 
 	ts_recheck_enable();
 
-	ts_service = service;
+    if (ts_service) {
+        connman_service_unref(ts_service);
+        ts_service = NULL;
+    }
+
+    if (service) {
+	    connman_service_ref(service);
+	    ts_service = service;
+    }
+
 	timeserver_sync_start();
 }
 
@@ -529,7 +543,10 @@ static void timeserver_stop(void)
 {
 	DBG(" ");
 
-	ts_service = NULL;
+	if (ts_service) {
+		connman_service_unref(ts_service);
+		ts_service = NULL;
+	}
 
 	if (resolv) {
 		g_resolv_unref(resolv);

--- a/src/timeserver.c
+++ b/src/timeserver.c
@@ -481,6 +481,21 @@ static const char * timeserver_sync_reason2string(
     return "unknown";
 }
 
+/**
+ *  @brief
+ *    Initiate a time of day sychronization with time services.
+ *
+ *  This initiates a time of day sychronization with time services for
+ *  the specified network service for the provided reason.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           object for which a time of day
+ *                           synchronization with time services should
+ *                           be initiated.
+ *  @param[in]      reason   The reason for the time of day
+ *                           synchronizization request.
+ *
+ */
 void __connman_timeserver_sync(struct connman_service *service,
 			enum connman_timeserver_sync_reason reason)
 {

--- a/src/timeserver.c
+++ b/src/timeserver.c
@@ -398,6 +398,23 @@ static void ts_set_nameservers(struct connman_service *service)
 	}
 }
 
+/**
+ *  @brief
+ *    Reset internal time of day synchronization state and initiate
+ *    time of day synchronization with the specified network service.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           object for which a time of day
+ *                           synchronization with time services should
+ *                           be initiated. Name and time servers from
+ *                           this service will be used for time of day
+ *                           synchronization.
+ *
+ *  @sa __connman_timeserver_sync
+ *  @sa __connman_timeserver_conf_update
+ *  @sa __connman_timeserver_system_set
+ *
+ */
 static void ts_reset(struct connman_service *service)
 {
 	DBG("service %p", service);


### PR DESCRIPTION
This fixes a heap-use-after-free fault in `connman_service_get_nameservers` on service removal by:

1. Qualifying the call to `__connman_timeserver_sync` in `__connman_service_ipconfig_indicate_state` with a `is_connected` conditional.
2. Converting the semantics of the `ts_service` private global in _src/timeservice.c_ from a weak reference (that is, it uses simple `=` assignment) to a strong reference (that is, it uses `connman_service_{ref,unref}`plus `=` assignment).