### PR TITLE
Address Memory Leak in '__connman_service_timeserver_remove'.

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -3044,8 +3044,10 @@ int __connman_service_timeserver_remove(struct connman_service *service,
 	for (i = 0, j = 0; i < len; i++) {
 		if (g_strcmp0(service->timeservers[i], timeserver) != 0) {
 			servers[j] = g_strdup(service->timeservers[i]);
-			if (!servers[j])
+			if (!servers[j]) {
+				g_strfreev(servers);
 				return -ENOMEM;
+			}
 			j++;
 		}
 	}


### PR DESCRIPTION
This partially address #2 by fixing a potential memory leak in `__connman_service_timeserver_remove` of memory pointed to by `servers` identified by clang/LLVM scan-build-11.