### PR TITLE
Address 'scan-build' Warning in 'get_ipv6_privacy'.

### DIFF
--- a/src/ipconfig.c
+++ b/src/ipconfig.c
@@ -366,13 +366,12 @@ static int set_ipv6_state(gchar *ifname, bool enable)
 
 static int get_ipv6_privacy(gchar *ifname)
 {
-	int value;
+	int value = 0;
 
 	if (!ifname)
-		return 0;
+		return value;
 
-	if (read_ipv6_conf_value(ifname, "use_tempaddr", &value) < 0)
-		value = 0;
+	read_ipv6_conf_value(ifname, "use_tempaddr", &value);
 
 	return value;
 }


### PR DESCRIPTION
This partially addresses #2 by fixing an "undefined or garbage value returned to caller [core.uninitialized.UndefReturn]" warning in `get_ipv6_privacy` identified by clang/LLVM `scan-build-11`.