### PR TITLE
Address 'scan-build' Warning in 'get_rp_filter'.

### DIFF
--- a/src/ipconfig.c
+++ b/src/ipconfig.c
@@ -392,10 +392,9 @@ static int set_ipv6_privacy(gchar *ifname, int value)
 
 static int get_rp_filter(void)
 {
-	int value;
+	int value = -EINVAL;
 
-	if (read_ipv4_conf_value(NULL, "rp_filter", &value) < 0)
-		value = -EINVAL;
+	read_ipv4_conf_value(NULL, "rp_filter", &value);
 
 	return value;
 }


### PR DESCRIPTION
This partially addresses #2 by fixing an "undefined or garbage value returned to caller [core.uninitialized.UndefReturn]" warning in `get_rp_filter` identified by clang/LLVM `scan-build-11`.