### PR TITLE
Rename 'start_wispr_when_connected'

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1602,7 +1602,7 @@ bool __connman_service_index_is_default(int index)
 	return __connman_service_get_index(service) == index;
 }
 
-static void start_wispr_when_connected(struct connman_service *service)
+static void start_wispr_if_connected(struct connman_service *service)
 {
 	if (!connman_setting_get_bool("EnableOnlineCheck")) {
 		connman_info("Online check disabled. "
@@ -1645,7 +1645,7 @@ static void default_changed(void)
 				connman_setting_get_bool("AllowDomainnameUpdates"))
 			__connman_utsname_set_domainname(service->domainname);
 
-		start_wispr_when_connected(service);
+		start_wispr_if_connected(service);
 
 		/*
 		 * Connect VPN automatically when new default service
@@ -3753,7 +3753,7 @@ static DBusMessage *set_property(DBusConnection *conn,
 		nameserver_add_all(service, CONNMAN_IPCONFIG_TYPE_ALL);
 		dns_configuration_changed(service);
 
-		start_wispr_when_connected(service);
+		start_wispr_if_connected(service);
 
 		service_save(service);
 	} else if (g_str_equal(name, "Timeservers.Configuration")) {


### PR DESCRIPTION
The current name, `start_wispr_when_connected` implies that a deferred action is "hooked" and that when the service becomes "connected"; a WISPr-based reachability probe will start. The revised name, `start_wispr_if_connected` implies, correctly, a one-shot chance to start WISPr if the service is "connected" at the time of the call.