### PR TITLE
Add a Callback Parameter to '__connman_wispr_start'.

### DIFF
--- a/src/connman.h
+++ b/src/connman.h
@@ -523,10 +523,15 @@ void __connman_wpad_cleanup(void);
 int __connman_wpad_start(struct connman_service *service);
 void __connman_wpad_stop(struct connman_service *service);
 
+typedef void (*__connman_wispr_cb_t) (struct connman_service *service,
+				enum connman_ipconfig_type type,
+				bool success);
+
 int __connman_wispr_init(void);
 void __connman_wispr_cleanup(void);
 int __connman_wispr_start(struct connman_service *service,
-					enum connman_ipconfig_type type);
+					enum connman_ipconfig_type type,
+					__connman_wispr_cb_t callback);
 void __connman_wispr_stop(struct connman_service *service);
 
 #include <connman/technology.h>
@@ -734,9 +739,6 @@ int __connman_service_set_mdns(struct connman_service *service,
 
 void __connman_service_set_string(struct connman_service *service,
 					const char *key, const char *value);
-void __connman_service_online_check(struct connman_service *service,
-					enum connman_ipconfig_type type,
-					bool success);
 int __connman_service_ipconfig_indicate_state(struct connman_service *service,
 					enum connman_service_state new_state,
 					enum connman_ipconfig_type type);

--- a/src/service.c
+++ b/src/service.c
@@ -157,6 +157,9 @@ static struct connman_ipconfig *create_ip6config(struct connman_service *service
 static void dns_changed(struct connman_service *service);
 static void vpn_auto_connect(void);
 static void trigger_autoconnect(struct connman_service *service);
+static void complete_online_check(struct connman_service *service,
+					enum connman_ipconfig_type type,
+					bool success);
 
 struct find_data {
 	const char *path;
@@ -3640,7 +3643,7 @@ void __connman_service_wispr_start(struct connman_service *service,
 		service->online_check_interval_ipv6 =
 					online_check_initial_interval;
 
-	__connman_wispr_start(service, type);
+	__connman_wispr_start(service, type, complete_online_check);
 }
 
 static DBusMessage *set_property(DBusConnection *conn,
@@ -6370,7 +6373,7 @@ static void redo_wispr(struct connman_service *service,
 		__connman_ipconfig_type2string(type),
 		service, service->name);
 
-	__connman_wispr_start(service, type);
+	__connman_wispr_start(service, type, complete_online_check);
 	connman_service_unref(service);
 }
 
@@ -6396,7 +6399,7 @@ static gboolean redo_wispr_ipv6(gpointer user_data)
 	return FALSE;
 }
 
-void __connman_service_online_check(struct connman_service *service,
+static void complete_online_check(struct connman_service *service,
 					enum connman_ipconfig_type type,
 					bool success)
 {


### PR DESCRIPTION
This partially addresses #6 by adding a callback parameter to `__connman_wispr_start `. This callback provides two benefits:

* The first is making static the implementation of the WISPr closure function defined in _src/service.c_.
* The second is that it will make easier closing several failure path "holes" that currently do not properly "bookend" requests to `__connman_wispr_start` by making the closure of those holes independent of the function providing the closure.