### PR TITLE
Close three '__connman_wisp_start' failure closure holes.

### DIFF
--- a/src/wispr.c
+++ b/src/wispr.c
@@ -549,6 +549,7 @@ static void wispr_portal_request_portal(
 					wp_context);
 
 	if (wp_context->request_id == 0) {
+		wp_context->cb(wp_context->service, wp_context->type, false);
 		wispr_portal_error(wp_context);
 		wispr_portal_context_unref(wp_context);
 	}
@@ -873,10 +874,20 @@ static void proxy_callback(const char *proxy, void *user_data)
 	struct connman_wispr_portal_context *wp_context = user_data;
 	char *proxy_server;
 
-	DBG("proxy %s", proxy);
+	DBG("wp_context %p proxy %p", wp_context, proxy);
 
-	if (!wp_context || !proxy)
+	if (!wp_context)
 		return;
+
+	if (!proxy) {
+		DBG("no valid proxy");
+
+		wp_context->cb(wp_context->service, wp_context->type, false);
+
+		return;
+	}
+
+	DBG("proxy %s", proxy);
 
 	wp_context->token = 0;
 
@@ -969,6 +980,8 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
 		g_web_add_nameserver(wp_context->web, nameservers[i]);
 
 	proxy_method = connman_service_get_proxy_method(wp_context->service);
+
+	DBG("proxy_method %d", proxy_method);
 
 	if (proxy_method != CONNMAN_SERVICE_PROXY_METHOD_DIRECT) {
 		wp_context->token = connman_proxy_lookup(interface,
@@ -1067,6 +1080,8 @@ int __connman_wispr_start(struct connman_service *service,
 	return 0;
 
 free_wp:
+	wp_context->cb(wp_context->service, wp_context->type, false);
+
 	g_hash_table_remove(wispr_portal_hash, GINT_TO_POINTER(index));
 	return err;
 }


### PR DESCRIPTION
There are currently three failure holes in which a request to `__connman_wispr_start` are not properly closed:

1. If `g_web_request_get` fails to generate a successful gweb request and returns a request identifier of zero (0) in `wispr_portal_request_portal`.
2. If the service proxy is set to `CONNMAN_SERVICE_PROXY_METHOD_UNKNOWN`. This can happen in `proxy_callback` if WISPr is started and the service proxy method is set latently or is never set at all.
3. If `wispr_portal_detect` returns non-zero error status in `__connman_wispr_start`.