### PR TITLE
Expand DBG content in WISPr 'wispr_portal_request_portal'.

### DIFF
--- a/src/wispr.c
+++ b/src/wispr.c
@@ -538,8 +538,11 @@ static bool wispr_route_request(const char *address, int ai_family,
 static void wispr_portal_request_portal(
 		struct connman_wispr_portal_context *wp_context)
 {
-	DBG("wp_context %p %s", wp_context,
-		__connman_ipconfig_type2string(wp_context->type));
+	DBG("wispr/portal context %p service %p (%s) type %d (%s)",
+		wp_context,
+		wp_context->service,
+		connman_service_get_identifier(wp_context->service),
+		wp_context->type, __connman_ipconfig_type2string(wp_context->type));
 
 	wispr_portal_context_ref(wp_context);
 	wp_context->request_id = g_web_request_get(wp_context->web,


### PR DESCRIPTION
As the functionality for _EnableOnlineToReadyTransition_ is further developed and there are multiple online checks in flight for multiple services and IP configuration types thereof, the expanded content in this `DBG` statement becomes critical to successfully tracking these unique online check operations.