### PR TITLE
Introduce the 'OnlineCheckIntervalStyle' Setting.

### DIFF
--- a/README
+++ b/README
@@ -409,9 +409,21 @@ from ipv4.connman.net (for IPv4 connectivity) and ipv6.connman.net
 http://ipv{4|6}.connman.net/online/status.html
 
 When an online check request fails, another one is triggered after a
-longer interval. The intervals follow the square series of numbers
-in a specific range, by default [1, 12], corresponding to the following
-intervals, in seconds: 1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121 and 144.
+longer interval. The intervals follows one of two mathemetical
+sequences, depending on the "OnlineCheckIntervalStyle" setting:
+"fibonacci" or "geometric", with a default of "geometric". The
+geometric setting is the square series of numbers in the range
+specified by "OnlineCheckInitialInterval" and "OnlineCheckMaxInterval".
+The default values for "OnlineCheckInitialInterval" and
+"OnlineCheckMaxInterval" are the range [1, 12], which correspond to the
+following "geometric" intervals, in seconds: 1, 4, 9, 16, 25, 36, 49, 64,
+81, 100, 121 and 144 over that range. By contrast, the correspending
+"fibonacci" sequence over that range is 1, 1, 2, 3, 5, 8, 13, 21, 34, 55,
+89, and 144. The "fibonacci" series and style is more aggressive in check
+rate up to 12 steps (its equivalence point with "geometric" at 144 seconds)
+than "geometric" but backs off far more aggressively past that point
+reaching an hour at interval 19 which "geometric" does not reach until
+interval 60.
 
 See connman.conf(5) for the EnableOnlineCheck option, if you need to
 disable the feature.

--- a/doc/connman.conf.5.in
+++ b/doc/connman.conf.5.in
@@ -179,6 +179,27 @@ Range of intervals between two online check requests.
 Please refer to the README for more detailed information.
 Default values are 1 and 12 respectively.
 .TP
+.BI OnlineCheckIntervalStyle=fibonacci\ \fR|\fB\ geometric
+The style or mathematical series function used to compute the actual
+time, in seconds, between two "ready" to "online" HTTP-based Internet
+reachability checks. The value of which may be either "geometric" or
+"fibonacci" with a default value of "geometric".
+
+The "geometric" style or function simply takes the square of the
+online check interval (see OnlineCheckInitialInterval and
+OnlineCheckMaxInterval above). For example, at a check interval of 6,
+the time, in seconds, is 36 (6^2) seconds.
+
+The "fibonacci" style or function takes the value of the Fibonacci
+sequence at the online check interval. For example, at a check interval
+of 6, the time, in seconds, is 8 seconds.
+
+The "fibonacci" series and style is more aggressive in check rate up to 12
+steps (its equivalence point with "geometric" at 144 seconds) than
+"geometric" but backs off far more aggressively past that point reaching
+an hour at interval 19 which "geometric" does not reach until interval
+60.
+.TP
 .BI EnableOnlineToReadyTransition=true\ \fR|\fB\ false
 WARNING: Experimental feature!!!
 In addition to EnableOnlineCheck setting, enable or disable use of HTTP GET

--- a/src/main.conf
+++ b/src/main.conf
@@ -150,6 +150,27 @@
 # default one, in replacement.
 # EnableOnlineToReadyTransition = false
 
+# The style or mathematical series function used to compute the actual
+# time, in seconds, between two "ready" to "online" HTTP-based Internet
+# reachability checks. The value of which may be either "geometric" or
+# "fibonacci".
+#
+# The "geometric" style or function simply takes the square of the
+# online check interval. For example, at a check interval of 6, the
+# time, in seconds, is 36 (6^2) seconds.
+#
+# The "fibonacci" style or function takes the value of the Fibonacci
+# sequence at the online check interval. For example, at a check
+# interval of 6, the time, in seconds, is 8 seconds.
+#
+# "fibonacci" is more aggressive in check rate up to 12 steps (its
+# equivalence point with "geometric" at 144 seconds) but is far less
+# aggressive past that point, reacing an hour at interval 19 compared
+# to "geometric" which does not reach an hour until interval 60.
+#
+# Default value is "geometric".
+# OnlineCheckIntervalStyle=geometric
+
 # List of technologies with AutoConnect = true which are always connected
 # regardless of PreferredTechnologies setting. Default value is empty and
 # will connect a technology only if it is at a higher preference than any

--- a/src/service.c
+++ b/src/service.c
@@ -45,6 +45,8 @@
 #define VPN_AUTOCONNECT_TIMEOUT_STEP 30
 #define VPN_AUTOCONNECT_TIMEOUT_ATTEMPTS_THRESHOLD 270
 
+typedef guint (*online_check_timeout_compute_t)(unsigned int interval);
+
 static DBusConnection *connection = NULL;
 
 static GList *service_list = NULL;
@@ -58,6 +60,8 @@ static bool services_dirty = false;
 static bool enable_online_to_ready_transition = false;
 static unsigned int online_check_initial_interval = 0;
 static unsigned int online_check_max_interval = 0;
+static const char *online_check_timeout_interval_style = NULL;
+static online_check_timeout_compute_t online_check_timeout_compute_func = NULL;
 
 struct connman_stats {
 	bool valid;
@@ -1439,6 +1443,82 @@ static bool check_proxy_setup(struct connman_service *service)
 	}
 
 	return false;
+}
+
+/**
+ *  @brief
+ *    Compute a Fibonacci online check timeout based on the specified
+ *    interval.
+ *
+ *  This computes the Fibonacci online check timeout, in seconds,
+ *  based on the specified interval in a Fibonacci series. For
+ *  example, an interval of 9 yields a timeout of 34 seconds.
+ *
+ *  @note
+ *    As compared to a geometric series, the Fibonacci series is
+ *    slightly less aggressive in backing off up to the equivalence
+ *    point at interval 12, but far more aggressive past that point,
+ *    climbing to past an hour at interval 19 whereas the geometric
+ *    series does not reach that point until interval 60.
+ *
+ *  @param[in]  interval  The interval in the geometric series for
+ *                        which to compute the online check timeout.
+ *
+ *  @returns
+ *    The timeout, in seconds, for the online check.
+ *
+ *  @sa online_check_timeout_compute_fibonacci
+ *
+ */
+static guint online_check_timeout_compute_fibonacci(unsigned int interval)
+{
+	unsigned int i;
+	guint first = 0;
+	guint second = 1;
+	guint timeout_seconds;
+
+	for (i = 0; i <= interval; i++) {
+		timeout_seconds = first;
+
+		first = second;
+
+		second = second + timeout_seconds;
+	}
+
+	return timeout_seconds;
+}
+
+/**
+ *  @brief
+ *    Compute a geometric online check timeout based on the specified
+ *    interval.
+ *
+ *  This computes the geometric online check timeout, in seconds,
+ *  based on the specified interval in a geometric series, where the
+ *  resulting value is interval^2. For example, an interval of 9
+ *  yields a timeout of 81 seconds.
+ *
+ *  @note
+ *    As compared to a Fibonacci series, the geometric series is
+ *    slightly more aggressive in backing off up to the equivalence
+ *    point at interval 12, but far less aggressive past that point,
+ *    only reaching an hour at interval 90 compared to interval 19 for
+ *    Fibonacci for a similar timeout.
+ *
+ *  @param[in]  interval  The interval in the geometric series for
+ *                        which to compute the online check timeout.
+ *
+ *  @returns
+ *    The timeout, in seconds, for the online check.
+ *
+ *  @sa online_check_timeout_compute_fibonacci
+ *
+ */
+static guint online_check_timeout_compute_geometric(unsigned int interval)
+{
+	const guint timeout_seconds = interval * interval;
+
+	return timeout_seconds;
 }
 
 static void cancel_online_check(struct connman_service *service)
@@ -6399,8 +6479,10 @@ static void complete_online_check(struct connman_service *service,
 {
 	GSourceFunc redo_func;
 	unsigned int *interval;
+	guint *timeout;
 	enum connman_service_state current_state;
-	int timeout;
+	guint seconds;
+	guint current_timeout;
 
 	DBG("service %p (%s) type %d (%s) success %d\n",
 		service,
@@ -6410,9 +6492,11 @@ static void complete_online_check(struct connman_service *service,
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4) {
 		interval = &service->online_check_interval_ipv4;
+		timeout = &service->online_timeout_ipv4;
 		redo_func = redo_wispr_ipv4;
 	} else {
 		interval = &service->online_check_interval_ipv6;
+		timeout = &service->online_timeout_ipv6;
 		redo_func = redo_wispr_ipv6;
 	}
 
@@ -6432,19 +6516,23 @@ static void complete_online_check(struct connman_service *service,
 	}
 
 redo_func:
-	DBG("service %p (%s) type %d (%s) interval %d", service,
+	DBG("updating online checkout timeout period");
+
+	seconds = online_check_timeout_compute_func(*interval);
+
+	DBG("service %p (%s) type %d (%s) interval %d style \"%s\" seconds %u",
+		service,
 		connman_service_get_identifier(service),
-		type, __connman_ipconfig_type2string(type), *interval);
+		type, __connman_ipconfig_type2string(type),
+		*interval, online_check_timeout_interval_style, seconds);
 
-	timeout = g_timeout_add_seconds(*interval * *interval,
+	current_timeout = g_timeout_add_seconds(seconds,
 				redo_func, connman_service_ref(service));
-	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
-		service->online_timeout_ipv4 = timeout;
-	else
-		service->online_timeout_ipv6 = timeout;
 
-	/* Increment the interval for the next time, set a maximum timeout of
-	 * online_check_max_interval seconds * online_check_max_interval seconds.
+	*timeout = current_timeout;
+
+	/* Increment the interval for the next time, limiting to a maximum
+	 * interval of @a online_check_max_interval.
 	 */
 	if (*interval < online_check_max_interval)
 		(*interval)++;
@@ -7869,6 +7957,13 @@ int __connman_service_init(void)
 
 	enable_online_to_ready_transition =
 		connman_setting_get_bool("EnableOnlineToReadyTransition");
+	online_check_timeout_interval_style =
+		connman_setting_get_string("OnlineCheckIntervalStyle");
+	if (g_strcmp0(online_check_timeout_interval_style, "fibonacci") == 0)
+		online_check_timeout_compute_func = online_check_timeout_compute_fibonacci;
+	else
+		online_check_timeout_compute_func = online_check_timeout_compute_geometric;
+
 	online_check_initial_interval =
 		connman_setting_get_uint("OnlineCheckInitialInterval");
 	online_check_max_interval =


### PR DESCRIPTION
This introduces the `OnlineCheckIntervalStyle` setting which is the style or mathematical series function used to compute the actual time, in seconds, between two `ready` to `online` HTTP-based Internet reachability checks. The value of which may be either _geometric_ or _fibonacci_ with a default value of _geometric_.

The _geometric_ style (which is a formalization of the existing, default series calculation) or function simply takes the square of the online check interval. For example, at a check interval of 6, the time, in seconds, is 36 (6^2) seconds.

The _fibonacci_ style or function takes the value of the Fibonacci sequence at the online check interval. For example, at a check interval of 6, the time, in seconds, is 8 seconds.

The _fibonacci_ series and style is more aggressive in check rate up to 12 steps (its equivalence point with _geometric_ at 144 seconds) than _geometric_ but backs off far more aggressively past that point reaching an hour at interval 19 which _geometric_ does not reach until interval 60.

As the `EnableOnlineToReadyTransition` is refined and further developed, the _fibonacci_ style will allow for faster service failover and recovery times for transient failures while backing off more aggressively for longer duration outages where metered services like Cellular may be more sensitive to a less aggressive backoff as with _geometric_.