### PR TITLE
Service: Leverage 'is_connected'.

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -2726,8 +2726,7 @@ static void append_properties(DBusMessageIter *dict, dbus_bool_t limited,
 	connman_dbus_dict_append_array(dict, "Nameservers.Configuration",
 				DBUS_TYPE_STRING, append_dnsconfig, service);
 
-	if (service->state == CONNMAN_SERVICE_STATE_READY ||
-			service->state == CONNMAN_SERVICE_STATE_ONLINE)
+	if (is_connected(service->state))
 		list = __connman_timeserver_get_all(service);
 	else
 		list = NULL;


### PR DESCRIPTION
In all instances but one where there are checks to see whether the IPv4 or IPv6 service state is `CONNMAN_SERVICE_STATE_READY` or `CONNMAN_SERVICE_STATE_ONLINE`, the `is_connected` function is used. This leverages `is_connected` for the only instance where that was not the case.