### PR TITLE
Add and Leverage Service Default Introspection Function

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1689,6 +1689,31 @@ struct connman_service *connman_service_get_default(void)
 
 /**
  *  @brief
+ *    Determine whether the specified service is the default service.
+ *
+ *  This determines whether the specified service is the default
+ *  service (that is, the service with the default route).
+ *
+ *  @param[in]  service  A pointer to the immutable service for which
+ *                       to determine whether it is the default
+ *                       network service.
+ *  @returns
+ *    True if the specified service is the default network service;
+ *    otherwise, false.
+ *
+ *  @sa connman_service_get_default
+ *
+ */
+static bool connman_service_is_default(const struct connman_service *service)
+{
+	if (!service)
+		return false;
+
+	return connman_service_get_default() == service;
+}
+
+/**
+ *  @brief
  *    Determine whether the specified network interface index belongs
  *    to the default service.
  *

--- a/src/service.c
+++ b/src/service.c
@@ -4915,6 +4915,14 @@ static void switch_default_service(struct connman_service *default_service,
 	struct connman_service *service;
 	GList *src, *dst;
 
+	DBG("default_service %p (%s) default %u downgrade_service %p (%s) default %u",
+		default_service,
+		connman_service_get_identifier(default_service),
+		connman_service_is_default(default_service),
+		downgrade_service,
+		connman_service_get_identifier(downgrade_service),
+		connman_service_is_default(downgrade_service));
+
 	apply_relevant_default_downgrade(default_service);
 	src = g_list_find(service_list, downgrade_service);
 	dst = g_list_find(service_list, default_service);


### PR DESCRIPTION
This adds an introspection function, `connman_service_is_default` to determine whether the specified service is the default service (that is, the service with the default route).

In addition, this adds a `DBG` statement to `switch_default_service` which leverages this newly-added function since, in the fullness of time, neither of the service arguments are guaranteed to be the default service.