### PR TITLE
Rename and Document 'switch_default_service'

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -4909,23 +4909,23 @@ static void apply_relevant_default_downgrade(struct connman_service *service)
 	downgrade_state(def_service);
 }
 
-static void switch_default_service(struct connman_service *default_service,
-		struct connman_service *downgrade_service)
+static void switch_service_order(struct connman_service *demoted_service,
+		struct connman_service *promoted_service)
 {
 	struct connman_service *service;
 	GList *src, *dst;
 
-	DBG("default_service %p (%s) default %u downgrade_service %p (%s) default %u",
-		default_service,
-		connman_service_get_identifier(default_service),
-		connman_service_is_default(default_service),
-		downgrade_service,
-		connman_service_get_identifier(downgrade_service),
-		connman_service_is_default(downgrade_service));
+	DBG("demoted_service %p (%s) default %u promoted_sevice %p (%s) default %u",
+		demoted_service,
+		connman_service_get_identifier(demoted_service),
+		connman_service_is_default(demoted_service),
+		promoted_service,
+		connman_service_get_identifier(promoted_service),
+		connman_service_is_default(promoted_service));
 
-	apply_relevant_default_downgrade(default_service);
-	src = g_list_find(service_list, downgrade_service);
-	dst = g_list_find(service_list, default_service);
+	apply_relevant_default_downgrade(demoted_service);
+	src = g_list_find(service_list, promoted_service);
+	dst = g_list_find(service_list, demoted_service);
 
 	/* Nothing to do */
 	if (src == dst || src->next == dst)
@@ -4935,7 +4935,7 @@ static void switch_default_service(struct connman_service *default_service,
 	service_list = g_list_delete_link(service_list, src);
 	service_list = g_list_insert_before(service_list, dst, service);
 
-	downgrade_state(downgrade_service);
+	downgrade_state(promoted_service);
 }
 
 static struct _services_notify {
@@ -5116,9 +5116,9 @@ int __connman_service_move(struct connman_service *service,
 	 * is triggered via downgrading it - if relevant - to state ready.
 	 */
 	if (before)
-		switch_default_service(target, service);
+		switch_service_order(target, service);
 	else
-		switch_default_service(service, target);
+		switch_service_order(service, target);
 
 	__connman_connection_update_gateway();
 
@@ -6204,7 +6204,7 @@ static int service_update_preferred_order(struct connman_service *default_servic
 		return 0;
 
 	if (service_compare_preferred(default_service, new_service) > 0) {
-		switch_default_service(default_service,
+		switch_service_order(default_service,
 				new_service);
 		__connman_connection_update_gateway();
 		return 0;

--- a/src/service.c
+++ b/src/service.c
@@ -4909,6 +4909,33 @@ static void apply_relevant_default_downgrade(struct connman_service *service)
 	downgrade_state(def_service);
 }
 
+/**
+ *  @brief
+ *    Switch the order of the two specified services in the network
+ *    service list.
+ *
+ *  This attempts to switch the order of the two specified services in
+ *  the ntework service list. This has the side-effect of potentially
+ *  downgrading the state of @a demoted_service from "online" to
+ *  "ready" if it is "online" and is the default service and
+ *  downgrading the state of @a promoted_service from "online" to
+ *  "ready".
+ *
+ *  @note
+ *    If the two services have pointer equivalence or are already in
+ *    the specified order, there is no state downgrade of @a
+ *    promoted_service.
+ *
+ *  @param[in,out]  demoted_service   A pointer to the mutable service
+ *                                    to demote in the network service
+ *                                    list to @b after @a
+ *                                    promoted_service.
+ *  @param[in,out]  promoted_service  A pointer to the mutable service
+ *                                    to promote in the network service
+ *                                    list to @b before @a
+ *                                    demoted_service.
+ *
+ */
 static void switch_service_order(struct connman_service *demoted_service,
 		struct connman_service *promoted_service)
 {


### PR DESCRIPTION
This renames and documents the `switch_default_service` function.

The function `switch_default_service` is used in two contexts:
    
1. From `__connman_service_move`, which may be called from either the public D-Bus _MoveAfter_ or _MoveBefore_ method requests or from `connman_provider_set_split_routing` in _src/provider.c_.
2. From `service_update_preferred_order` in which the first argument is guaranteed to the default service.3. 

In the D-Bus _MoveAfter_ or _MoveBefore_ contexts, the `switch_default_service` is a misnomer since neither service argument, in particular the first, is guaranteed to be the default service. Consequently, `switch_default_service` is renamed to the more neutral `switch_service_order` to reflect its varied usage in the above contexts.
