### PR TITLE
Add Debug and Documentation to WISPr-related Functions

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -6676,9 +6676,9 @@ static void service_rp_filter(struct connman_service *service,
 static void redo_wispr(struct connman_service *service,
 					enum connman_ipconfig_type type)
 {
-	DBG("Retrying %s WISPr for %p %s",
-		__connman_ipconfig_type2string(type),
-		service, service->name);
+	DBG("Retrying service %p (%s) type %d (%s) WISPr",
+		service, connman_service_get_identifier(service),
+		type, __connman_ipconfig_type2string(type));
 
 	__connman_wispr_start(service, type, complete_online_check);
 	connman_service_unref(service);

--- a/src/service.c
+++ b/src/service.c
@@ -1526,6 +1526,31 @@ static guint online_check_timeout_compute_geometric(unsigned int interval)
 	return timeout_seconds;
 }
 
+/**
+ *  @brief
+ *    Cancel any "online" HTTP-based Internet reachability checks for
+ *    the specified network service.
+ *
+ *  This cancels any current or pending IPv4 and/or IPv6 "online"
+ *  HTTP-based Internet reachability checks for the specified network
+ *  service.
+ *
+ *  @note
+ *    Any lingering WISPr portal reachability context will be lazily
+ *    released at the start of the next online check for the service
+ *    and replaced with new context.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           for which any current or pending IPv4 or
+ *                           IPv6 "online" reachability checks should
+ *                           be canceled.
+ *
+ *  @sa start_online_check
+ *  @sa complete_online_check
+ *  @sa __connman_wispr_start
+ *  @sa __connman_wispr_stop
+ *
+ */
 static void cancel_online_check(struct connman_service *service)
 {
 	DBG("service %p (%s) online_timeout_ipv4 %d online_timeout_ipv6 %d",
@@ -1545,6 +1570,32 @@ static void cancel_online_check(struct connman_service *service)
 	}
 }
 
+/**
+ *  @brief
+ *    Start an "online" HTTP-based Internet reachability check for the
+ *    specified network service IP configuration type.
+ *
+ *  This attempts to start an "online" HTTP-based Internet
+ *  reachability check for the specified network service IP
+ *  configuration type.
+ *
+ *  @note
+ *    Any check is skipped, with an informational log message, if @a
+ *    EnableOnlineCheck is not asserted.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           for which to start the "online"
+ *                           reachability check.
+ *  @param[in]      type     The IP configuration type for which the
+ *                           "online" reachability check is to be
+ *                           started.
+ *
+ *  @sa cancel_online_check
+ *  @sa complete_online_check
+ *  @sa start_wispr_if_connected
+ *  @sa __connman_service_wispr_start
+ *
+ */
 static void start_online_check(struct connman_service *service,
 				enum connman_ipconfig_type type)
 {
@@ -3777,6 +3828,28 @@ int __connman_service_reset_ipconfig(struct connman_service *service,
 	return err;
 }
 
+/**
+ *  @brief
+ *    Start an "online" HTTP-based Internet reachability check for the
+ *    specified network service IP configuration type.
+ *
+ *  This attempts to start an "online" HTTP-based Internet
+ *  reachability check for the specified network service IP
+ *  configuration type.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           for which to start the "online"
+ *                           reachability check.
+ *  @param[in]      type     The IP configuration type for which the
+ *                           "online" reachability check is to be
+ *                           started.
+ *
+ *  @sa cancel_online_check
+ *  @sa start_online_check
+ *  @sa complete_online_check
+ *  @sa start_wispr_if_connected
+ *
+ */
 void __connman_service_wispr_start(struct connman_service *service,
 					enum connman_ipconfig_type type)
 {
@@ -6673,6 +6746,25 @@ static void service_rp_filter(struct connman_service *service,
 		connected_networks_count, original_rp_filter);
 }
 
+/**
+ *  @brief
+ *    Retry an "online" HTTP-based Internet reachability check.
+ *
+ *  This retries an "online" HTTP-based Internet reachability check
+ *  for the specified network service IP configuration type.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           for which an "online" reachability check
+ *                           should be retried.
+ *  @param[in]      type     The IP configuration type for which an
+ *                           "online" reachability check should be
+ *                           retried.
+ *
+ *  @sa complete_online_check
+ *  @sa redo_wispr_ipv4
+ *  @sa redo_wispr_ipv6
+ *
+ */
 static void redo_wispr(struct connman_service *service,
 					enum connman_ipconfig_type type)
 {
@@ -6681,9 +6773,36 @@ static void redo_wispr(struct connman_service *service,
 		type, __connman_ipconfig_type2string(type));
 
 	__connman_wispr_start(service, type, complete_online_check);
+
+	// Release the reference to the service taken when
+	// g_timeout_add_seconds was invoked with the callback
+	// that, in turn, invoked this function.
+
 	connman_service_unref(service);
 }
 
+/**
+ *  @brief
+ *    Retry an "online" HTTP-based Internet reachability check
+ *    callback.
+ *
+ *  This callback retries an IPv4 "online" HTTP-based Internet
+ *  reachability check for the specified network service.
+ *
+ *  @param[in,out]  user_data  A pointer to the mutable network
+ *                             service for which an IPv4 "online"
+ *                             reachability check should be retried.
+ *
+ *  @returns
+ *    FALSE (that is, G_SOURCE_REMOVE) unconditionally, indicating
+ *    that the timeout source that triggered this callback should be
+ *    removed on callback completion.
+ *
+ *  @sa complete_online_check
+ *  @sa redo_wispr
+ *  @sa redo_wispr_ipv6
+ *
+ */
 static gboolean redo_wispr_ipv4(gpointer user_data)
 {
 	struct connman_service *service = user_data;
@@ -6695,6 +6814,28 @@ static gboolean redo_wispr_ipv4(gpointer user_data)
 	return FALSE;
 }
 
+/**
+ *  @brief
+ *    Retry an "online" HTTP-based Internet reachability check
+ *    callback.
+ *
+ *  This callback retries an IPv6 "online" HTTP-based Internet
+ *  reachability check for the specified network service.
+ *
+ *  @param[in,out]  user_data  A pointer to the mutable network
+ *                             service for which an IPv6 "online"
+ *                             reachability check should be retried.
+ *
+ *  @returns
+ *    FALSE (that is, G_SOURCE_REMOVE) unconditionally, indicating
+ *    that the timeout source that triggered this callback should be
+ *    removed on callback completion.
+ *
+ *  @sa complete_online_check
+ *  @sa redo_wispr
+ *  @sa redo_wispr_ipv4
+ *
+ */
 static gboolean redo_wispr_ipv6(gpointer user_data)
 {
 	struct connman_service *service = user_data;
@@ -6706,6 +6847,48 @@ static gboolean redo_wispr_ipv6(gpointer user_data)
 	return FALSE;
 }
 
+/**
+ *  @brief
+ *    This completes an "online" HTTP-based Internet reachability
+ *    check for the specified network service and IP configuration
+ *    type.
+ *
+ *  This completes a failed or successful "online" HTTP-based Internet
+ *  reachability check for the specified network service and IP
+ *  configuration type. This effectively "bookends" an earlier
+ *  #__connman_service_wispr_start.
+ *
+ *  If "EnableOnlineToReadyTransition" is deasserted and if @a success
+ *  is asserted, then the state for the specified IP configuration
+ *  type is transitioned to "online" and a future online check is
+ *  scheduled based on the current interval and the
+ *  "OnlineCheckIntervalStyle" setting.
+ *
+ *  Otherwise, if "EnableOnlineToReadyTransition" is asserted, then
+ *  counters are managed for the success or failure and state is
+ *  managed and tracked resulting in the potential demotion of the
+ *  service, placing it into a temporary failure state until such time
+ *  as a series of back-to-back online checks successfully
+ *  complete. If the service is a non-default after demotion and it is
+ *  in failure state or if it is the default service, then a future
+ *  online check is scheduled based on the current interval and the
+ *  "OnlineCheckIntervalStyle" setting.
+ *
+ *  @param[in,out]  service  A pointer to the mutable service for which
+ *                           to complete a previously-requested online
+ *                           check.
+ *  @param[in]      type     The IP configuration type for which to
+ *                           complete a previously-requested online
+ *                           check.
+ *  @param[in]      success  A Boolean indicating whether the previously-
+ *                           requested online check was successful.
+ *
+ *  @sa cancel_online_check
+ *  @sa start_online_check
+ *  @sa start_wispr_if_connected
+ *  @sa __connman_service_wispr_start
+ *
+ */
 static void complete_online_check(struct connman_service *service,
 					enum connman_ipconfig_type type,
 					bool success)

--- a/src/service.c
+++ b/src/service.c
@@ -1528,6 +1528,11 @@ static guint online_check_timeout_compute_geometric(unsigned int interval)
 
 static void cancel_online_check(struct connman_service *service)
 {
+	DBG("service %p (%s) online_timeout_ipv4 %d online_timeout_ipv6 %d",
+		service, connman_service_get_identifier(service),
+		service->online_timeout_ipv4,
+		service->online_timeout_ipv6);
+
 	if (service->online_timeout_ipv4) {
 		g_source_remove(service->online_timeout_ipv4);
 		service->online_timeout_ipv4 = 0;
@@ -1543,6 +1548,12 @@ static void cancel_online_check(struct connman_service *service)
 static void start_online_check(struct connman_service *service,
 				enum connman_ipconfig_type type)
 {
+	DBG("service %p (%s) type %d (%s) maybe start WISPr",
+		service,
+		connman_service_get_identifier(service),
+		type,
+		__connman_ipconfig_type2string(type));
+
 	if (!connman_setting_get_bool("EnableOnlineCheck")) {
 		connman_info("Online check disabled. "
 			"Default service remains in READY state.");


### PR DESCRIPTION
This adds `DBG` statements and function documentation to service WISPr-related functions to aid in debugging and correlating multiple in-flight `online` check attempts that exist in a multi-technology environment with `EnableOnlineToReadyTransition` asserted.