### PR TITLE
service: Enhance 'DBG' in '__connman_service_indicate_default'

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -6746,7 +6746,9 @@ int __connman_service_clear_error(struct connman_service *service)
 
 int __connman_service_indicate_default(struct connman_service *service)
 {
-	DBG("service %p state %s", service, state2string(service->state));
+	DBG("service %p (%s) state %d (%s)",
+		service, connman_service_get_identifier(service),
+		service->state, state2string(service->state));
 
 	if (!is_connected(service->state)) {
 		/*


### PR DESCRIPTION
This enhances the `DBG` statement in `__connman_service_indicate_default' by adding the service identifier. In addition, it aligns the content and format with other `DBG` functions in the module to make debugging and at- a-glance correlation easier, especially in a multi-technology environment with `EnableOnlineToReadyTransition` asserted.