### PR TITLE
service: Add 'DBG' statement to 'start_wispr_if_connected'.

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1870,6 +1870,10 @@ redo_func:
  */
 static void start_wispr_if_connected(struct connman_service *service)
 {
+	DBG("service %p (%s) maybe start WISPr",
+		service,
+		connman_service_get_identifier(service));
+
 	if (!connman_setting_get_bool("EnableOnlineCheck")) {
 		connman_info("Online check disabled. "
 			"Default service remains in READY state.");


### PR DESCRIPTION
This adds a `DBG` statement to `start_wispr_if_connected` to aid in debugging and correlating WISPr online checks in flight in a multi- technology environment with _EnableOnlineToReadyTransition_ asserted.