### PR TITLE
Terminate all Online Check Handling in One Function

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1845,7 +1845,14 @@ static void complete_online_check(struct connman_service *service,
 		redo_func = redo_wispr_ipv6;
 	}
 
-	if(!enable_online_to_ready_transition)
+	if (success) {
+		__connman_service_ipconfig_indicate_state(service,
+			CONNMAN_SERVICE_STATE_ONLINE,
+			type);
+
+		if (!enable_online_to_ready_transition)
+			return;
+	} else if (!enable_online_to_ready_transition)
 		goto redo_func;
 
 	if (success) {

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -97,7 +97,6 @@ static GHashTable *wispr_portal_hash = NULL;
 
 static char *online_check_ipv4_url = NULL;
 static char *online_check_ipv6_url = NULL;
-static bool enable_online_to_ready_transition = false;
 
 #define wispr_portal_context_ref(wp_context) \
 	wispr_portal_context_ref_debug(wp_context, __FILE__, __LINE__, __func__)
@@ -480,11 +479,7 @@ static void portal_manage_status(GWebResult *result,
 				&str))
 		connman_info("Client-Timezone: %s", str);
 
-	__connman_service_ipconfig_indicate_state(service,
-					CONNMAN_SERVICE_STATE_ONLINE, type);
-
-	if (enable_online_to_ready_transition)
-		wp_context->cb(service, type, true);
+	wp_context->cb(service, type, true);
 }
 
 static bool wispr_route_request(const char *address, int ai_family,
@@ -1127,9 +1122,6 @@ int __connman_wispr_init(void)
 		connman_setting_get_string("OnlineCheckIPv4URL");
 	online_check_ipv6_url =
 		connman_setting_get_string("OnlineCheckIPv6URL");
-
-	enable_online_to_ready_transition =
-		connman_setting_get_bool("EnableOnlineToReadyTransition");
 
 	return 0;
 }


### PR DESCRIPTION
This modifies `portal_manage_status` by moving the unconditional transition of the service to the 'online' state for which a HTTP-based reachability check was successfully completed to the callback provided to `__connman_wispr_start`, specifically, `complete_online_check`. This places all handling, both failure and success, of HTTP-based reachability checks in a single, auditable location in a single function in a single source file.