### PR TITLE
Document and Rename 'portal_manage_status'

### DIFF
--- a/src/wispr.c
+++ b/src/wispr.c
@@ -453,7 +453,7 @@ static void wispr_portal_error(struct connman_wispr_portal_context *wp_context)
 	wp_context->wispr_result = CONNMAN_WISPR_RESULT_FAILED;
 }
 
-static void portal_manage_status(GWebResult *result,
+static void portal_manage_success_status(GWebResult *result,
 			struct connman_wispr_portal_context *wp_context)
 {
 	struct connman_service *service = wp_context->service;
@@ -783,7 +783,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 
 		if (g_web_result_get_header(result, "X-ConnMan-Status",
 						&str)) {
-			portal_manage_status(result, wp_context);
+			portal_manage_success_status(result, wp_context);
 		} else {
 			wispr_portal_context_ref(wp_context);
 			__connman_agent_request_browser(wp_context->service,

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -453,6 +453,29 @@ static void wispr_portal_error(struct connman_wispr_portal_context *wp_context)
 	wp_context->wispr_result = CONNMAN_WISPR_RESULT_FAILED;
 }
 
+/**
+ *  @brief
+ *    Handle a successful "online" HTTP-based Internet reachability
+ *    check.
+ *
+ *  This handles a successful (that is, completed with a HTTP 200 "OK"
+ *  status code) "online" HTTP-based Internet reachability check
+ *  previously-initiated with #__connman_wispr_start.
+ *
+ *  @param[in]      result      A pointer to the mutable HTTP result
+ *                              for the successful "online" HTTP-based
+ *                              Internet reachability check this is
+ *                              handling.
+ *  @param[in,out]  wp_context  A pointer to the mutable WISPr portal
+ *                              detection context associated the
+ *                              successful "online" HTTP-based
+ *                              Internet reachability check this is
+ *                              handling.
+ *
+ *  @sa __connman_wispr_start
+ *  @sa wispr_portal_web_result
+ *
+ */
 static void portal_manage_success_status(GWebResult *result,
 			struct connman_wispr_portal_context *wp_context)
 {


### PR DESCRIPTION
This documents and renames `portal_manage_status`.

The function is renamed from `portal_manage_status` to `portal_manage_success_status` as it exclusively handles HTTP 200 "OK" success status and no others.
