### PR TITLE
Change and Leverage Downgrade Function Return Signature

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -5254,6 +5254,57 @@ static bool check_suitable_state(enum connman_service_state a,
 
 /**
  *  @brief
+ *    Downgrade the service IP configuration state from "online" to
+ *    "ready".
+ *
+ *  This attempts to downgrade the specified IP configuration state of
+ *  the specified service to "ready" if it is "online".
+ *
+ *  @param[in,out]  service  A pointer to the mutable service whose IP
+ *                           configuration state, if
+ *                           #CONNMAN_SERVICE_STATE_ONLINE, is to be
+ *                           downgraded to
+ *                           #CONNMAN_SERVICE_STATE_READY.
+ *  @param[in]      state    The current IP configuration state of @a
+ *                           service.
+ *  @param[in]      type     The IP configuration type of @a service to
+ *                           try to downgrade.
+ *
+ *  @returns
+ *    True if the service state was downgraded for the specified IP
+ *    configuration type; otherwise, false.
+ *
+ *  @sa service_downgrade_online_state
+ *  @sa service_downgrade_online_state_if_default
+ *
+ */
+static bool service_ipconfig_downgrade_online_state(
+					struct connman_service *service,
+					enum connman_service_state state,
+					enum connman_ipconfig_type type)
+{
+	if (!service)
+		return false;
+
+	DBG("service %p (%s) type %d (%s) state %d (%s)",
+		service,
+		connman_service_get_identifier(service),
+		type, __connman_ipconfig_type2string(type),
+		state, state2string(state));
+
+	if (is_online(state)) {
+		__connman_service_ipconfig_indicate_state(service,
+						CONNMAN_SERVICE_STATE_READY,
+						type);
+
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ *  @brief
  *    Downgrade the service IPv4 and IPv6 states from "online" to
  *    "ready".
  *

--- a/src/service.c
+++ b/src/service.c
@@ -1825,7 +1825,6 @@ static void complete_online_check(struct connman_service *service,
 	GSourceFunc redo_func;
 	unsigned int *interval;
 	guint *timeout;
-	enum connman_service_state current_state;
 	guint seconds;
 	guint current_timeout;
 
@@ -1858,9 +1857,7 @@ static void complete_online_check(struct connman_service *service,
 	if (success) {
 		*interval = online_check_max_interval;
 	} else {
-		current_state = service->state;
-		service_downgrade_online_state(service);
-		if (current_state != service->state)
+		if (service_downgrade_online_state(service))
 			*interval = online_check_initial_interval;
 		if (service != connman_service_get_default()) {
 			return;

--- a/src/service.c
+++ b/src/service.c
@@ -164,7 +164,7 @@ static void trigger_autoconnect(struct connman_service *service);
 static void complete_online_check(struct connman_service *service,
 					enum connman_ipconfig_type type,
 					bool success);
-static void service_downgrade_online_state(struct connman_service *service);
+static bool service_downgrade_online_state(struct connman_service *service);
 
 struct find_data {
 	const char *path;
@@ -5317,13 +5317,21 @@ static bool service_ipconfig_downgrade_online_state(
  *                           downgraded to
  *                           #CONNMAN_SERVICE_STATE_READY.
  *
+ *  @returns
+ *    True if either IPv4 or IPv6 service state was downgraded;
+ *    otherwise, false.
+ *
+ *  @sa service_ipconfig_downgrade_online_state
  *  @sa service_downgrade_online_state_if_default
  *
  */
-static void service_downgrade_online_state(struct connman_service *service)
+static bool service_downgrade_online_state(struct connman_service *service)
 {
+	bool ipv4_downgraded = false;
+	bool ipv6_downgraded = false;
+
 	if (!service)
-		return;
+		return false;
 
 	DBG("service %p (%s) state4 %d (%s) state6 %d (%s)",
 		service,
@@ -5331,15 +5339,15 @@ static void service_downgrade_online_state(struct connman_service *service)
 		service->state_ipv4, state2string(service->state_ipv4),
 		service->state_ipv6, state2string(service->state_ipv6));
 
-	if (is_online(service->state_ipv4))
-		__connman_service_ipconfig_indicate_state(service,
-						CONNMAN_SERVICE_STATE_READY,
-						CONNMAN_IPCONFIG_TYPE_IPV4);
+	ipv4_downgraded = service_ipconfig_downgrade_online_state(service,
+								 service->state_ipv4,
+								 CONNMAN_IPCONFIG_TYPE_IPV4);
 
-	if (is_online(service->state_ipv6))
-		__connman_service_ipconfig_indicate_state(service,
-						CONNMAN_SERVICE_STATE_READY,
-						CONNMAN_IPCONFIG_TYPE_IPV6);
+	ipv6_downgraded = service_ipconfig_downgrade_online_state(service,
+								 service->state_ipv6,
+								 CONNMAN_IPCONFIG_TYPE_IPV6);
+
+	return ipv4_downgraded || ipv6_downgraded;
 }
 
 /**
@@ -5359,19 +5367,24 @@ static void service_downgrade_online_state(struct connman_service *service)
  *                           downgraded to
  *                           #CONNMAN_SERVICE_STATE_READY.
  *
+ *  @returns
+ *    True if either IPv4 or IPv6 service state was downgraded;
+ *    otherwise, false.
+ *
+ *  @sa service_ipconfig_downgrade_online_state
  *  @sa service_downgrade_online_state
  *
  */
-static void service_downgrade_online_state_if_default(struct connman_service *service)
+static bool service_downgrade_online_state_if_default(struct connman_service *service)
 {
 	struct connman_service *def_service;
 
 	def_service = connman_service_get_default();
 	if (!def_service || def_service != service ||
 		!is_online(def_service->state))
-		return;
+		return false;
 
-	service_downgrade_online_state(def_service);
+	return service_downgrade_online_state(def_service);
 }
 
 /**


### PR DESCRIPTION
This adds the function `service_ipconfig_downgrade_online_state` which attempts to downgrade the specified IP configuration state of the specified service to `ready` if it is `online`.

In addition, it leverages `service_ipconfig_downgrade_online_state` by reimplementing `service_downgrade_online_state` and
`service_downgrade_online_state_if_default` against it. In addition, the return signatures of `service_downgrade_online_state` and `service_downgrade_online_state_if_default` are changed from `void` to
`bool` to allow callers to know, without additional sideband checks, whether service state was downgraded.

Finally, this newly-changed `bool` return status of `service_downgrade_online_state` in `complete_online_check` is leveraged to avoid polling service state before and after the call to `service_downgrade_online_state` to determine whether to take downgrade-specific action.