### PR TITLE
Refactor and Document GWeb Parsing Functions to Handle IPv6 Bracketed Hosts in URLs

### DIFF
--- a/gweb/gweb.c
+++ b/gweb/gweb.c
@@ -23,6 +23,7 @@
 #include <config.h>
 #endif
 
+#include <ctype.h>
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -1107,99 +1108,479 @@ static int create_transport(struct web_session *session)
 	return 0;
 }
 
+static int parse_url_scheme_with_default(const char *url, size_t url_length,
+						const char **cursor,
+						char **scheme,
+						const char *default_scheme)
+{
+	static const char * const scheme_delimiter = "://";
+	static const size_t scheme_delimiter_length = 3;
+	const char *result;
+	size_t remaining_length;
+	size_t scheme_length = 0;
+
+	if (!url || !url_length || !cursor)
+		return -EINVAL;
+
+	remaining_length = (url_length - (size_t)(*cursor - url));
+	if (remaining_length) {
+		result = (const char *)memmem(*cursor,
+							remaining_length,
+							scheme_delimiter,
+							scheme_delimiter_length);
+		if (result) {
+			scheme_length = (size_t)(result - *cursor);
+
+			if (scheme) {
+				*scheme = g_strndup(*cursor, scheme_length);
+				if (!*scheme)
+					return -ENOMEM;
+			}
+
+			*cursor += scheme_length + scheme_delimiter_length;
+		} else if (scheme && default_scheme) {
+			scheme_length = strlen(default_scheme);
+
+			*cursor += scheme_length;
+
+			*scheme = g_strndup(default_scheme, scheme_length);
+			if (!*scheme)
+				return -ENOMEM;
+		} else if (scheme)
+			*scheme = NULL;
+	} else if (scheme)
+		*scheme = NULL;
+
+	return 0;
+}
+
+static int parse_url_scheme(const char *url, size_t url_length,
+						const char **cursor,
+						char **scheme)
+{
+	const char * const default_scheme = NULL;
+
+	return parse_url_scheme_with_default(url,
+		url_length,
+		cursor,
+		scheme,
+		default_scheme);
+}
+
+static int parse_url_host(const char *url, size_t url_length,
+						const char **cursor,
+						char **host)
+{
+	size_t remaining_length;
+	size_t host_length	= 0;
+	const char *result;
+	const char *opening_bracket;
+	const char *closing_bracket;
+
+	if (!url || !url_length || !cursor)
+		return -EINVAL;
+
+	// Since it's the easiest to detect, first rule out an IPv6
+	// address. The only reliably way to do so is to search for the
+	// delimiting '[' and ']'. Searching for ':' may yield one of the
+	// other forms above (for example, (2), (5), or (7).
+
+	remaining_length = (url_length - (size_t)(*cursor - url));
+
+	opening_bracket = (const char *)memchr(*cursor, '[', remaining_length);
+	if (opening_bracket) {
+		// We found an opening bracket; this might be an IPv6
+		// address. Search for its peer closing bracket.
+
+		remaining_length = (url_length - (size_t)(opening_bracket - url));
+
+		closing_bracket = (const char *)memchr(opening_bracket,
+									']',
+									remaining_length);
+		if (!closing_bracket)
+			return -EINVAL;
+
+		// Assign the first character of the IPv6 address after the
+		// opening bracket up to, but not including, the closing
+		// bracket to the host name.
+
+		host_length = (size_t)(closing_bracket - opening_bracket) - 1;
+
+		if (host) {
+			*host = g_strndup(opening_bracket + 1, host_length);
+			if (!*host)
+				return -ENOMEM;
+		}
+
+		// Move the parsing cursor past the closing bracket.
+
+		*cursor = closing_bracket + 1;
+	} else {
+		// At this point, we either have an IPv4 address or a host
+		// name, maybe with a port.
+		//
+		// Whether we have a port or not, we definitively know where
+		// the IPv4 address or host name ends. If we have a port, it
+		// ends at the port delimiter, ':'. If we don't have a port,
+		// then it ends at the end of the string or at the path
+		// delimiter, if any.
+
+		result = (const char *)memchr(*cursor, ':', remaining_length);
+		if (result) {
+			// There is a port and an IPv4 address or a host name.
+			// Assign the latter to the host and handle the port
+			// later.
+
+			host_length = (size_t)(result - *cursor);
+
+			if (host) {
+				*host = g_strndup(*cursor, host_length);
+				if (!*host)
+					return -ENOMEM;
+			}
+
+			*cursor += host_length;
+		} else {
+			// There is no port, just an IPv4 address or a host name,
+			// potentially followed by a path.
+
+			result = (const char *)memchr(*cursor, '/', remaining_length);
+			if (result)
+				host_length = (size_t)(result - *cursor);
+			else
+				host_length = remaining_length;
+
+			if (host) {
+				*host = g_strndup(*cursor, host_length);
+				if (!*host)
+					return -ENOMEM;
+			}
+
+			*cursor += host_length;
+		}
+	}
+
+	if (!host_length)
+		return -EINVAL;
+
+	return 0;
+}
+
+static int parse_url_port(const char *url, size_t url_length,
+						const char **cursor,
+						int16_t *port)
+{
+	static char port_delimiter = ':';
+	static const size_t port_delimiter_length = 1;
+	const char *result;
+	size_t remaining_length;
+	size_t port_length = 0;
+	char *end;
+	unsigned long tmp_port;
+
+	if (!url || !url_length || !cursor)
+		return -EINVAL;
+
+	remaining_length = (url_length - (size_t)(*cursor - url));
+
+	result = (const char *)memchr(*cursor, port_delimiter, remaining_length);
+	if (result) {
+		tmp_port = strtoul(result + port_delimiter_length, &end, 10);
+		if (tmp_port == ULONG_MAX)
+			return -ERANGE;
+		else if (tmp_port < 0 || tmp_port > UINT16_MAX)
+			return -ERANGE;
+		else if (result + 1 == end)
+			return -EINVAL;
+
+		if (*end != '\0')
+			port_length = remaining_length;
+		else
+			port_length = end - (result + port_delimiter_length);
+
+		*cursor += port_length;
+	} else
+		tmp_port = -1;
+
+	if (port)
+		*port = (int16_t)tmp_port;
+
+	return 0;
+}
+
+static int parse_url_host_and_port(const char *url, size_t url_length,
+						const char **cursor,
+						char **host,
+						int16_t *port)
+{
+	int err;
+
+	if (!url || !url_length || !cursor)
+		return -EINVAL;
+
+	// Attempt to handle the host component.
+
+	err = parse_url_host(url, url_length, cursor, host);
+	if (err != 0)
+		return err;
+
+	// Attempt to handle the port component.
+
+	err = parse_url_port(url, url_length, cursor, port);
+	if (err != 0) {
+		if (host) {
+			g_free(*host);
+			*host = NULL;
+		}
+
+		return err;
+	}
+
+	return 0;
+}
+
+static int parse_url_path(const char *url, size_t url_length,
+						const char **cursor,
+						char **path)
+{
+	static char path_delimiter = '/';
+	static const size_t path_delimiter_length = 1;
+	const char *result;
+	size_t remaining_length;
+	size_t path_length = 0;
+
+	if (!url || !url_length || !cursor)
+		return -EINVAL;
+
+	remaining_length = (url_length - (size_t)(*cursor - url));
+
+	result = (const char *)memchr(*cursor, path_delimiter, remaining_length);
+	if (result) {
+		path_length = (url_length - (size_t)(result + path_delimiter_length - url));
+
+		if (path) {
+			*path = g_strndup(result + path_delimiter_length, path_length);
+			if (!*path)
+				return -ENOMEM;
+		}
+
+		*cursor += path_length + path_delimiter_length;
+	} else if (path)
+		*path = NULL;
+
+	return 0;
+}
+
+static int parse_url_components(const char *url,
+						char **scheme,
+						char **host,
+						int16_t *port,
+						char **path)
+{
+	size_t total_length;
+	const char *p;
+	int err;
+
+	if (!url)
+		return -EINVAL;
+
+	p = url;
+
+	total_length = strlen(p);
+	if (!total_length)
+		return -EINVAL;
+
+	// Skip any leading space, if any.
+
+	while ((p < (url + total_length)) && isspace(*p))
+		p++;
+
+	// Attempt to handle the scheme component.
+
+	err = parse_url_scheme(url, total_length, &p, scheme);
+	if (err != 0)
+		return err;
+
+	// Attempt to handle the host component.
+
+	err = parse_url_host_and_port(url, total_length, &p, host, port);
+	if (err != 0) {
+		if (scheme) {
+			g_free(*scheme);
+			*scheme = NULL;
+		}
+
+		return err;
+	}
+
+	// Attempt to handle the path component.
+
+	err = parse_url_path(url, total_length, &p, path);
+	if (err != 0) {
+		if (scheme) {
+			g_free(*scheme);
+			*scheme = NULL;
+		}
+
+		if (host) {
+			g_free(*host);
+			*host = NULL;
+		}
+
+		return err;
+	}
+
+	return 0;
+}
+
 static int parse_request_and_proxy_urls(struct web_session *session,
 				const char *url, const char *proxy)
 {
-	char *scheme, *host, *port, *path;
+	size_t proxy_length;
+	const char *p;
+	char *scheme = NULL;
+	char *host = NULL;
+	char *path = NULL;
+	int16_t port = -1;
+	int err;
 
-	scheme = g_strdup(url);
-	if (!scheme)
+	if (!session || !url)
 		return -EINVAL;
 
-	host = strstr(scheme, "://");
-	if (host) {
-		*host = '\0';
-		host += 3;
+	p = url;
 
+	// Parse the URL components.
+
+	err = parse_url_components(url,
+							   &scheme,
+							   &host,
+							   &port,
+							   &path);
+	if (err != 0) {
+		g_free(scheme);
+		g_free(host);
+		g_free(path);
+
+		return err;
+	}
+
+	// Handle the URL scheme, if any, for the session, defaulting to
+	// the "http" scheme and port 80.
+
+	if (scheme) {
 		if (strcasecmp(scheme, "https") == 0) {
 			session->port = 443;
-			session->flags |= SESSION_FLAG_USE_TLS;
 		} else if (strcasecmp(scheme, "http") == 0) {
 			session->port = 80;
 		} else {
 			g_free(scheme);
+			g_free(host);
+			g_free(path);
 			return -EINVAL;
 		}
+
+		g_free(scheme);
 	} else {
-		host = scheme;
 		session->port = 80;
 	}
 
-	path = strchr(host, '/');
-	if (path)
-		*(path++) = '\0';
+	// Handle the URL host and port, if any, for the session.
 
-	if (!proxy)
-		session->request = g_strdup_printf("/%s", path ? path : "");
-	else
-		session->request = g_strdup(url);
+	if (port != -1) {
+		session->port = port;
 
-	port = strrchr(host, ':');
-	if (port) {
-		char *end;
-		int tmp = strtol(port + 1, &end, 10);
-
-		if (*end == '\0') {
-			*port = '\0';
-			session->port = tmp;
-		}
-
-		if (!proxy)
+		if (!proxy) {
 			session->host = g_strdup(host);
-		else
-			session->host = g_strdup_printf("%s:%u", host, tmp);
-	} else
+			if (!session->host) {
+				g_free(host);
+				g_free(path);
+				return -ENOMEM;
+			}
+		} else {
+			session->host = g_strdup_printf("%s:%u", host, port);
+			if (!session->host) {
+				g_free(host);
+				g_free(path);
+				return -ENOMEM;
+			}
+		}
+	} else {
 		session->host = g_strdup(host);
+		if (!session->host) {
+			g_free(host);
+			g_free(path);
+			return -ENOMEM;
+		}
+	}
 
-	g_free(scheme);
+	// Handle the URL path, if any, for the session.
+
+	if (!proxy) {
+		session->request = g_strdup_printf("/%s", path ? path : "");
+		if (!session->request) {
+			g_free(host);
+			g_free(path);
+			return -ENOMEM;
+		}
+	} else {
+		session->request = g_strdup(url);
+		if (!session->request) {
+			g_free(host);
+			g_free(path);
+			return -ENOMEM;
+		}
+	}
+
+	g_free(host);
+	g_free(path);
 
 	if (!proxy)
 		return 0;
 
-	scheme = g_strdup(proxy);
-	if (!scheme)
-		return -EINVAL;
+	// Parse the proxy scheme, host, and port, the only three
+	// components we care about.
 
-	host = strstr(proxy, "://");
-	if (host) {
-		*host = '\0';
-		host += 3;
+	p = proxy;
+	proxy_length = strlen(p);
 
-		if (strcasecmp(scheme, "http") != 0) {
-			g_free(scheme);
-			return -EINVAL;
-		}
-	} else
-		host = scheme;
+	err = parse_url_scheme(proxy,
+						   proxy_length,
+						   &p,
+						   &scheme);
+	if (err != 0)
+		return err;
 
-	path = strchr(host, '/');
-	if (path)
-		*(path++) = '\0';
+	err = parse_url_host_and_port(proxy,
+								  proxy_length,
+								  &p,
+								  &host,
+								  &port);
+	if (err != 0) {
+		g_free(scheme);
 
-	port = strrchr(host, ':');
-	if (port) {
-		char *end;
-		int tmp = strtol(port + 1, &end, 10);
-
-		if (*end == '\0') {
-			*port = '\0';
-			session->port = tmp;
-		}
+		return err;
 	}
 
-	session->address = g_strdup(host);
+	// Handle the proxy URL scheme, if any, for the session. Only
+	// "http" is allowed.
 
-	g_free(scheme);
+	if (scheme) {
+		if (strcasecmp(scheme, "http") != 0) {
+			g_free(scheme);
+			g_free(host);
+			return -EINVAL;
+		}
+
+		g_free(scheme);
+	}
+
+	// Handle the proxy URL host and port for the session.
+
+	if (host)
+		session->address = host;
+
+	if (port != -1)
+		session->port = port;
 
 	return 0;
 }

--- a/gweb/gweb.c
+++ b/gweb/gweb.c
@@ -1108,6 +1108,48 @@ static int create_transport(struct web_session *session)
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Attempt to parse the scheme component from a URL with an
+ *    optional default fallback.
+ *
+ *  This attempts to parse the scheme component from the specified URL
+ *  of the provided length at the specified cursor point in the
+ *  URL. If a scheme cannot be parsed, the provided optional default
+ *  fallback is used. If provided, the parsed scheme is copied and
+ *  assigned to @a scheme.
+ *
+ *  @note
+ *    The caller is responsible for deallocating the memory assigned
+ *    to @a *scheme, if provided, on success.
+ *
+ *  @param[in]      url             A pointer to the immutable null-
+ *                                  terminated C string from which to
+ *                                  parse the scheme component.
+ *  @param[in]      url_length      The length, in bytes, of @a url.
+ *  @param[in,out]  cursor          A pointer to the current parsing
+ *                                  position within @a url at which to
+ *                                  start parsing the scheme. On
+ *                                  success, this is updated to the
+ *                                  first byte past the parsed scheme.
+ *  @param[in,out]  scheme          An optional pointer to storage to
+ *                                  assign a copy of the parsed scheme
+ *                                  on success.
+ *  @param[in]      default_scheme  An optional pointer to the immutable
+ *                                  null-terminated C string to use of
+ *                                  a scheme cannot be parsed from @a
+ *                                  url at @a cursor.
+ *
+ *  @retval  0        If successful.
+ *  @retavl  -EINVAL  If @a url was null, @a url_length was zero, or @a
+ *                    cursor was null.
+ *  @retval  -ENOMEM  If memory could not be allocated for the parsed
+ *                    scheme.
+ *
+ *  @sa parse_url_scheme
+ *  @sa parse_url_components
+ *
+ */
 static int parse_url_scheme_with_default(const char *url, size_t url_length,
 						const char **cursor,
 						char **scheme,
@@ -1154,6 +1196,42 @@ static int parse_url_scheme_with_default(const char *url, size_t url_length,
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Attempt to parse the scheme component from a URL.
+ *
+ *  This attempts to parse the scheme component from the specified URL
+ *  of the provided length at the specified cursor point in the
+ *  URL. If provided, the parsed scheme is copied and
+ *  assigned to @a scheme.
+ *
+ *  @note
+ *    The caller is responsible for deallocating the memory assigned
+ *    to @a *scheme, if provided, on success.
+ *
+ *  @param[in]      url             A pointer to the immutable null-
+ *                                  terminated C string from which to
+ *                                  parse the scheme component.
+ *  @param[in]      url_length      The length, in bytes, of @a url.
+ *  @param[in,out]  cursor          A pointer to the current parsing
+ *                                  position within @a url at which to
+ *                                  start parsing the scheme. On
+ *                                  success, this is updated to the
+ *                                  first byte past the parsed scheme.
+ *  @param[in,out]  scheme          An optional pointer to storage to
+ *                                  assign a copy of the parsed scheme
+ *                                  on success.
+ *
+ *  @retval  0        If successful.
+ *  @retavl  -EINVAL  If @a url was null, @a url_length was zero, or @a
+ *                    cursor was null.
+ *  @retval  -ENOMEM  If memory could not be allocated for the parsed
+ *                    scheme.
+ *
+ *  @sa parse_url_scheme_with_default
+ *  @sa parse_url_components
+ *
+ */
 static int parse_url_scheme(const char *url, size_t url_length,
 						const char **cursor,
 						char **scheme)
@@ -1167,6 +1245,53 @@ static int parse_url_scheme(const char *url, size_t url_length,
 		default_scheme);
 }
 
+/**
+ *  @brief
+ *    Attempt to parse the host component from a URL.
+ *
+ *  This attempts to parse the host component from the specified
+ *  URL of the provided length at the specified cursor point in the
+ *  URL. If provided, the parsed host is copied and assigned to @a
+ *  host.
+ *
+ *  Compliant with RFC 2732, the format of the host component of the
+ *  URL may be one of the following:
+ *
+ *    1. "[\<IPv6 Address>]"
+ *    2. "[\<IPv6 Address>]:<Port>"
+ *    4. "\<IPv4 Address>"
+ *    5. "\<IPv4 Address>:<Port>"
+ *    6. "\<Host Name>"
+ *    7. "\<Host Name>:<Port>"
+ *
+ *  @note
+ *    The caller is responsible for deallocating the memory assigned
+ *    to @a *host, if provided, on success.
+ *
+ *  @param[in]      url             A pointer to the immutable null-
+ *                                  terminated C string from which to
+ *                                  parse the host component.
+ *  @param[in]      url_length      The length, in bytes, of @a url.
+ *  @param[in,out]  cursor          A pointer to the current parsing
+ *                                  position within @a url at which to
+ *                                  start parsing the host. On
+ *                                  success, this is updated to the
+ *                                  first byte past the parsed host.
+ *  @param[in,out]  host            An optional pointer to storage to
+ *                                  assign a copy of the parsed host
+ *                                  on success.
+ *
+ *  @retval  0        If successful.
+ *  @retavl  -EINVAL  If @a url was null, @a url_length was zero, @a
+ *                    cursor was null, or if the host portion of @a
+ *                    url is malformed.
+ *  @retval  -ENOMEM  If memory could not be allocated for the parsed
+ *                    host.
+ *
+ *  @sa parse_url_host_and_port
+ *  @sa parse_url_components
+ *
+ */
 static int parse_url_host(const char *url, size_t url_length,
 						const char **cursor,
 						char **host)
@@ -1266,6 +1391,50 @@ static int parse_url_host(const char *url, size_t url_length,
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Attempt to parse the port component from a URL.
+ *
+ *  This attempts to parse the port component from the specified URL
+ *  of the provided length at the specified cursor point in the
+ *  URL. If provided, the parsed port is assigned to @a port.
+ *
+ *  Compliant with RFC 2732, the format of the host component of the
+ *  URL may be one of the following:
+ *
+ *    1. "[\<IPv6 Address>]"
+ *    2. "[\<IPv6 Address>]:<Port>"
+ *    4. "\<IPv4 Address>"
+ *    5. "\<IPv4 Address>:<Port>"
+ *    6. "\<Host Name>"
+ *    7. "\<Host Name>:<Port>"
+ *
+ *  @param[in]      url             A pointer to the immutable null-
+ *                                  terminated C string from which to
+ *                                  parse the port component.
+ *  @param[in]      url_length      The length, in bytes, of @a url.
+ *  @param[in,out]  cursor          A pointer to the current parsing
+ *                                  position within @a url at which to
+ *                                  start parsing the port. On
+ *                                  success, this is updated to the
+ *                                  first byte past the parsed port.
+ *  @param[in,out]  port            An optional pointer to storage to
+ *                                  assign the parsed port on
+ *                                  success. On failure or absence of
+ *                                  a port to parsed, this is assigned
+ *                                  -1.
+ *
+ *  @retval  0        If successful.
+ *  @retavl  -EINVAL  If @a url was null, @a url_length was zero, @a
+ *                    cursor was null, or if there were no characters
+ *                    to parse after the port delimiter (':').
+ *  @retval  -ERANGE  If the parsed port was outside of the range [0,
+ *                    65535], inclusive.
+ *
+ *  @sa parse_url_host_and_port
+ *  @sa parse_url_components
+ *
+ */
 static int parse_url_port(const char *url, size_t url_length,
 						const char **cursor,
 						int16_t *port)
@@ -1308,6 +1477,63 @@ static int parse_url_port(const char *url, size_t url_length,
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Attempt to parse the host and port components from a URL.
+ *
+ *  This attempts to parse the host and port components from the
+ *  specified URL of the provided length at the specified cursor point
+ *  in the URL. If provided, the parsed host is copied and assigned to
+ *  @a host and, if provided, the parsed port is assigned to @a port.
+ *
+ *  Compliant with RFC 2732, the format of the host component of the
+ *  URL may be one of the following:
+ *
+ *    1. "[\<IPv6 Address>]"
+ *    2. "[\<IPv6 Address>]:<Port>"
+ *    4. "\<IPv4 Address>"
+ *    5. "\<IPv4 Address>:<Port>"
+ *    6. "\<Host Name>"
+ *    7. "\<Host Name>:<Port>"
+ *
+ *  @note
+ *    The caller is responsible for deallocating the memory assigned
+ *    to @a *host, if provided, on success.
+ *
+ *  @param[in]      url             A pointer to the immutable null-
+ *                                  terminated C string from which to
+ *                                  parse the host and port components.
+ *  @param[in]      url_length      The length, in bytes, of @a url.
+ *  @param[in,out]  cursor          A pointer to the current parsing
+ *                                  position within @a url at which to
+ *                                  start parsing the host and
+ *                                  port. On success, this is updated
+ *                                  to the first byte past the parsed
+ *                                  host or port, if present.
+ *  @param[in,out]  host            An optional pointer to storage to
+ *                                  assign a copy of the parsed host
+ *                                  on success.
+ *  @param[in,out]  port            An optional pointer to storage to
+ *                                  assign the parsed port on
+ *                                  success. On failure or absence of
+ *                                  a port to parsed, this is assigned
+ *                                  -1.
+ *
+ *  @retval  0        If successful.
+ *  @retavl  -EINVAL  If @a url was null, @a url_length was zero, @a
+ *                    cursor was null, if the host portion of @a url
+ *                    is malformed, or if there were no characters to
+ *                    parse after the port delimiter (':').
+ *  @retval  -ENOMEM  If memory could not be allocated for the parsed
+ *                    host.
+ *  @retval  -ERANGE  If the parsed port was outside of the range [0,
+ *                    65535], inclusive.
+ *
+ *  @sa parse_url_host
+ *  @sa parse_url_port
+ *  @sa parse_url_components
+ *
+ */
 static int parse_url_host_and_port(const char *url, size_t url_length,
 						const char **cursor,
 						char **host,
@@ -1339,6 +1565,41 @@ static int parse_url_host_and_port(const char *url, size_t url_length,
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Attempt to parse the path component from a URL.
+ *
+ *  This attempts to parse the path component from the specified
+ *  URL of the provided length at the specified cursor point in the
+ *  URL. If provided, the parsed path is copied and assigned to @a
+ *  path.
+ *
+ *  @note
+ *    The caller is responsible for deallocating the memory assigned
+ *    to @a *path, if provided, on success.
+ *
+ *  @param[in]      url             A pointer to the immutable null-
+ *                                  terminated C string from which to
+ *                                  parse the path component.
+ *  @param[in]      url_length      The length, in bytes, of @a url.
+ *  @param[in,out]  cursor          A pointer to the current parsing
+ *                                  position within @a url at which to
+ *                                  start parsing the path. On
+ *                                  success, this is updated to the
+ *                                  first byte past the parsed path.
+ *  @param[in,out]  path            An optional pointer to storage to
+ *                                  assign a copy of the parsed path
+ *                                  on success.
+ *
+ *  @retval  0        If successful.
+ *  @retavl  -EINVAL  If @a url was null, @a url_length was zero, or @a
+ *                    cursor was null.
+ *  @retval  -ENOMEM  If memory could not be allocated for the parsed
+ *                    path.
+ *
+ *  @sa parse_url_components
+ *
+ */
 static int parse_url_path(const char *url, size_t url_length,
 						const char **cursor,
 						char **path)
@@ -1371,6 +1632,62 @@ static int parse_url_path(const char *url, size_t url_length,
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Attempt to parse the scheme, host, port, and path components
+ *    from a URL.
+ *
+ *  This attempts to parse the scheme, host, port, and path components
+ *  from the specified URL. If provided, the parsed scheme, host and
+ *  path are copied and assigned to @a scheme, @a host, and @a path,
+ *  respective and the parsed port is assigned to @a port.
+ *
+ *  Compliant with RFC 2732, the format of the host component of the
+ *  URL may be one of the following:
+ *
+ *    1. "[\<IPv6 Address>]"
+ *    2. "[\<IPv6 Address>]:<Port>"
+ *    4. "\<IPv4 Address>"
+ *    5. "\<IPv4 Address>:<Port>"
+ *    6. "\<Host Name>"
+ *    7. "\<Host Name>:<Port>"
+ *
+ *  @param[in]      url             A pointer to the immutable null-
+ *                                  terminated C string from which to
+ *                                  parse the scheme component.
+ *  @param[in,out]  scheme          An optional pointer to storage to
+ *                                  assign a copy of the parsed scheme
+ *                                  on success.
+ *  @param[in,out]  host            An optional pointer to storage to
+ *                                  assign a copy of the parsed host
+ *                                  on success.
+ *  @param[in,out]  port            An optional pointer to storage to
+ *                                  assign the parsed port on
+ *                                  success. On failure or absence of
+ *                                  a port to parsed, this is assigned
+ *                                  -1.
+ *  @param[in,out]  path            An optional pointer to storage to
+ *                                  assign a copy of the parsed path
+ *                                  on success.
+ *
+ *  @retval  0        If successful.
+ *  @retavl  -EINVAL  If @a url was null, @a url length was zero, if
+ *                    the host portion of @a url is malformed, or if
+ *                    there were no characters to parse after the port
+ *                    delimiter (':').
+ *  @retval  -ENOMEM  If memory could not be allocated for the parsed
+ *                    scheme, host, or path.
+ *  @retval  -ERANGE  If the parsed port was outside of the range [0,
+ *                    65535], inclusive.
+ *
+ *  @sa parse_url_scheme_with_default
+ *  @sa parse_url_scheme
+ *  @sa parse_url_host
+ *  @sa parse_url_port
+ *  @sa parse_url_host_and_port
+ *  @sa parse_url_path
+ *
+ */
 static int parse_url_components(const char *url,
 						char **scheme,
 						char **host,
@@ -1433,6 +1750,51 @@ static int parse_url_components(const char *url,
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Attempt to parse the request and proxy URLs for the web request
+ *    session.
+ *
+ *  This attempts to parse the specified request and optional proxy
+ *  URL for the specified web request session. From the request URL,
+ *  the scheme is parsed, mapped and assigned to the @a session port
+ *  field and the host and path are parsed, copied, and assigned to
+ *  the host and request fields, respectively. From the proxy URL, if
+ *  present, the port component is parsed and assigned to the @a
+ *  session port field and the host component is parsed, copied, and
+ *  assigned to the address field.
+ *
+ *  Compliant with RFC 2732, the format of the host component of the
+ *  request and proxy URLs may be one of the following:
+ *
+ *    1. "[\<IPv6 Address>]"
+ *    2. "[\<IPv6 Address>]:<Port>"
+ *    4. "\<IPv4 Address>"
+ *    5. "\<IPv4 Address>:<Port>"
+ *    6. "\<Host Name>"
+ *    7. "\<Host Name>:<Port>"
+ *
+ *  @note
+ *    The caller is responsible for deallocating the memory assigned
+ *    to the @a session host, request, and address fields.
+ *
+ *  @param[in,out]  session  A pointer to the mutable web session request
+ *                           object to be populated from @a url and,
+ *                           if provided, @a proxy. On success, the
+ *                           session port, host, request, and address
+ *                           fields will be populated from the parsed
+ *                           request URL and/or proxy URLs.
+ *  @param[in]      url      A pointer to the immutable null-terminated
+ *                           C string containing the request URL to
+ *                           parse.
+ *  @param[in]      proxy    An optional pointer to the immutable null-
+ *                           terminated C string containing the web
+ *                           proxy URL, if any, to parse.
+ *
+ *  @retval  0         If successful.
+ *  @retval  -EINVAL  If @url was not a valid URL.
+ *
+ */
 static int parse_request_and_proxy_urls(struct web_session *session,
 				const char *url, const char *proxy)
 {

--- a/gweb/gweb.c
+++ b/gweb/gweb.c
@@ -1107,7 +1107,7 @@ static int create_transport(struct web_session *session)
 	return 0;
 }
 
-static int parse_url(struct web_session *session,
+static int parse_request_and_proxy_urls(struct web_session *session,
 				const char *url, const char *proxy)
 {
 	char *scheme, *host, *port, *path;
@@ -1297,7 +1297,7 @@ static guint do_request(GWeb *web, const char *url,
 	if (!session)
 		return 0;
 
-	if (parse_url(session, url, web->proxy) < 0) {
+	if (parse_request_and_proxy_urls(session, url, web->proxy) < 0) {
 		free_session(session);
 		return 0;
 	}


### PR DESCRIPTION
This addresses #64 by renaming _GWeb_ `parse_url` to `parse_request_and_proxy_urls`, refactoring it, and documenting it.

Prior to this change, `parse_request_and_proxy_urls` failed to correctly handle RFC 2732-compliant URLs with bracketed IPv6 addresses such as:
    
> http://[2001:db8:4006:812::200e]:8080/online/status.html
    
Such bracketing is necessary when using IPv6 addresses to disambiguate the host component from the port component due to the presence of the colon (`:`) in IPv6 addresses. As such, prior to this change,  such URLs resulted in the **both** brackets **and** the IPv6 address being passed to _GResolv_ which, unsurprisingly, failed to successfully forward resolve since the resulting host was neither a valid host name nor a valid IPv6 address.

As a result, support for such RFC 2732-compliant bracketed IPv6 addresses has been added with this change which refactors the previously-monolithic `parse_request_and_proxy_urls` into several, focused functions:
    
* `parse_request_and_proxy_urls`
    * `parse_url_components`
        * `parse_url_scheme`
            * `parse_url_scheme_with_default`
        * `parse_url_host_and_port`
            * `parse_url_host`
            * `parse_url_port`
        * `parse_url_path`
    
In particular, `parse_url_host` is the new function responsible for parsing the host and correctly handling one of seven possible combinations of host and port, two of which include bracketed IPv6  addresses.
    
In addition, `parse_url_host` will now return an error on an empty, non-existent host and `parse_url_port` will return an error on invalid, out-of-range ports.