### PR TITLE
wispr: Avoid 'connman_proxy_lookup' call for 'CONNMAN_SERVICE_PROXY_METHOD_UNKNOWN'

### DIFF
--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1004,7 +1004,15 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
 
 	DBG("proxy_method %d", proxy_method);
 
-	if (proxy_method != CONNMAN_SERVICE_PROXY_METHOD_DIRECT) {
+	/*
+	 * Include both CONNMAN_SERVICE_PROXY_METHOD_UNKNOWN and
+	 * CONNMAN_SERVICE_PROXY_METHOD_DIRECT in avoiding a call to
+	 * connman_proxy_lookup, since the former will always result in
+	 * a WISPr request "falling down a hole" that will only ever
+	 * result in a failure completion.
+	 */
+	if ((proxy_method != CONNMAN_SERVICE_PROXY_METHOD_DIRECT) &&
+		(proxy_method != CONNMAN_SERVICE_PROXY_METHOD_UNKNOWN)) {
 		wp_context->token = connman_proxy_lookup(interface,
 						wp_context->status_url,
 						wp_context->service,


### PR DESCRIPTION
For certain network interfaces, such as Ethernet, that go through the state machine to `READY` rapidly, it is possible that the HTTP-based "online" reachablility WISPr probe will be initiated before the corresponding network service has its proxy method set. In such instances, the proxy method is still set to `CONNMAN_SERVICE_PROXY_METHOD_UNKNOWN` from the initial service initialization. Consequently, when the WISPr request wends its way to `wispr_portal_detect`, it would previously invoke `connman_proxy_lookup`. Unfortunately, for such a method, there is no corresponding proxy driver and the lookup will, eventually, unconditionally fail  resulting in a wasted WISPr check.

This change adds `CONNMAN_SERVICE_PROXY_METHOD_UNKNOWN` alongside `CONNMAN_SERVICE_PROXY_METHOD_DIRECT` as the two proxy methods for which a call to `connman_proxy_lookup` are avoided. This shunts the logic to the `no_proxy_callback` callback, which assumes a direct proxy method and results in a successful and unwasted WISPr reachability check for such cases.