### PR TITLE
wispr: Address Reference Counting heap-use-after-free Fault in 'free_wispr_routes'

### DIFF
--- a/src/wispr.c
+++ b/src/wispr.c
@@ -93,6 +93,11 @@ struct connman_wispr_portal {
 
 static bool wispr_portal_web_result(GWebResult *result, gpointer user_data);
 
+/**
+ *  A dictionary / hash table of network interface indices to
+ *  active / outstanding WISPr / portal request contexts.
+ *
+ */
 static GHashTable *wispr_portal_hash = NULL;
 
 static char *online_check_ipv4_url = NULL;

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -164,6 +164,13 @@ static void free_wispr_routes(struct connman_wispr_portal_context *wp_context)
 static void free_connman_wispr_portal_context(
 		struct connman_wispr_portal_context *wp_context)
 {
+	DBG("wispr/portal context %p service %p (%s) type %d (%s)",
+		wp_context,
+		wp_context->service,
+		connman_service_get_identifier(wp_context->service),
+		wp_context->type,
+		__connman_ipconfig_type2string(wp_context->type));
+
 	if (wp_context->wispr_portal) {
 		if (wp_context->wispr_portal->ipv4_context == wp_context)
 			wp_context->wispr_portal->ipv4_context = NULL;

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -574,6 +574,11 @@ static void wispr_portal_request_portal(
 		connman_service_get_identifier(wp_context->service),
 		wp_context->type, __connman_ipconfig_type2string(wp_context->type));
 
+	/*
+	 * Retain a reference to the WISPr/portal context to account for
+	 * 'g_web_request_get' maintaining a weak reference to it. This will
+	 * be released in the 'wispr_portal_web_result' callback.
+	 */
 	wispr_portal_context_ref(wp_context);
 	wp_context->request_id = g_web_request_get(wp_context->web,
 					wp_context->status_url,
@@ -873,6 +878,12 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 	wp_context->request_id = 0;
 done:
 	wp_context->wispr_msg.message_type = -1;
+
+	/*
+	 * Release a reference to the WISPr/portal context to balance the
+	 * earlier reference retained to account for 'g_web_request_get'
+	 * maintaining a weak reference to it.
+	 */
 	wispr_portal_context_unref(wp_context);
 	return false;
 }


### PR DESCRIPTION
This patch series adds documentation, `DBG` statements, and balances WISPr/portal context reference counting with proxy handling that leads to a heap-use-after-free fault in `free_wispr_routes`.
