### PR TITLE
Add Configurable Online Check TCP Connection Timeout

### DIFF
--- a/doc/connman.conf.5.in
+++ b/doc/connman.conf.5.in
@@ -174,6 +174,15 @@ Please refer to the README for more detailed information.
 Default values are http://ipv4.connman.net/online/status.html and
 http://ipv6.connman.net/online/status.html respectively.
 .TP
+.BI OnlineCheckConnectTimeout= secs[.milliseconds]
+The time, in decimal seconds (for example, 12.3), to wait for a
+successful TCP connection to the host associated with
+\fBOnlineCheckIPv4URL\fR or \fBOnlineCheckIPv6URL\fR (see above). Connections
+that take longer than \fBOnlineCheckConnectTimeout\fR will be aborted. The
+default value is zero ('0') which indicates that no explicit
+connection timeout will be used, leaving the timeout to the underlying
+operating system and network stack.
+.TP
 .BI OnlineCheckInitialInterval= secs, OnlineCheckMaxInterval= secs
 Range of intervals between two online check requests.
 Please refer to the README for more detailed information.

--- a/gweb/gweb.c
+++ b/gweb/gweb.c
@@ -178,6 +178,27 @@ static inline void call_route_func(struct web_session *session)
 				session->web->index, session->user_data);
 }
 
+/**
+ *  @brief
+ *    Handle a TCP connection timeout.
+ *
+ *  This callback handles a TCP connection timeout for a GWeb
+ *  connection. The session transport is closed and the GWeb
+ *  transaction is terminated with
+ *  #GWEB_HTTP_STATUS_CODE_REQUEST_TIMEOUT status.
+ *
+ *  param[in,out]  user_data  A pointer to the mutable GWeb session
+ *                            for which the TCP connection timed out.
+ *
+ *  @returns
+ *    G_SOURCE_REMOVE (that is, FALSE) unconditionally, indicating
+ *    that the timeout source that triggered this callback should be
+ *    removed on callback completion.
+ *
+ *  @sa add_connect_timeout
+ *  @sa cancel_connect_timeout
+ *
+ */
 static gboolean connect_timeout_cb(gpointer user_data)
 {
 	struct web_session *session = user_data;
@@ -197,6 +218,30 @@ static gboolean connect_timeout_cb(gpointer user_data)
 	return G_SOURCE_REMOVE;
 }
 
+/**
+ *  @brief
+ *    Add a TCP connection timeout.
+ *
+ *  This attempts to add TCP connection timeout and callback to the
+ *  specified GWeb session. The timeout is successfully added if @a
+ *  session is non-null and @a timeout_ms is greater than zero.
+ *
+ *  @param[in,out]  session     A pointer to the mutable GWeb session
+ *                              to add the TCP connection timeout
+ *                              callback to.
+ *  param[in]       timeout_ms  The time, in milliseconds, for the TCP
+ *                              connection timeout. Connections that
+ *                              take longer than this will be
+ *                              aborted. A value of zero ('0')
+ *                              indicates that no explicit connection
+ *                              timeout will be used, leaving the
+ *                              timeout to the underlying operating
+ *                              system and its network stack.
+ *
+ *  @sa cancel_connect_timeout
+ *  @sa connect_timeout_cb
+ *
+ */
 static void add_connect_timeout(struct web_session *session,
 						guint timeout_ms)
 {
@@ -209,6 +254,22 @@ static void add_connect_timeout(struct web_session *session,
 				connect_timeout_cb, session);
 }
 
+/**
+ *  @brief
+ *    Cancel a TCP connection timeout.
+ *
+ *  This attempts to cancel a TCP connection timeout and callback from
+ *  the specified GWeb session. The timeout is successfully cancelled
+ *  if @a session is non-null and its associated connect timeout
+ *  identifier is valid.
+ *
+ *  @param[in,out]  session     A pointer to the mutable GWeb session
+ *                              on which to cancel the TCP connection
+ *                              timeout.
+ *
+ *  @sa add_connect_timeout
+ *
+ */
 static void cancel_connect_timeout(struct web_session *session)
 {
 	if (!session)
@@ -222,6 +283,21 @@ static void cancel_connect_timeout(struct web_session *session)
 	}
 }
 
+/**
+ *  @brief
+ *    Close the TCP transport a GWeb sesssion.
+ *
+ *  This closes the TCP transport associated with the specified GWeb
+ *  session, removing its transport and send watches and releasing the
+ *  reference to the transport channel.
+ *
+ *  @param[in,out]  session     A pointer to the mutable GWeb session
+ *                              for which to close the session
+ *                              transport.
+ *
+ *  @sa connect_session_transport
+ *
+ */
 static void close_session_transport(struct web_session *session)
 {
 	if (!session)
@@ -532,6 +608,28 @@ bool g_web_get_close_connection(GWeb *web)
 	return web->close_connection;
 }
 
+/**
+ *  @brief
+ *    Set the TCP connection timeout.
+ *
+ *  This sets the TCP connection timeout, in milliseconds, for the
+ *  specified GWeb object.
+ *
+ *  param[in,out]  web         A pointer to the mutable GWeb object
+ *                             for which the TCP connection timeout is
+ *                             to be set.
+ *  param[in]      timeout_ms  The time, in milliseconds, for the TCP
+ *                             connection timeout. Connections that
+ *                             take longer than this will be
+ *                             aborted. A value of zero ('0')
+ *                             indicates that no explicit connection
+ *                             timeout will be used, leaving the
+ *                             timeout to the underlying operating
+ *                             system and its network stack.
+ *
+ *  @sa g_web_get_connect_timeout
+ *
+ */
 void g_web_set_connect_timeout(GWeb *web, guint timeout_ms)
 {
 	if (!web)
@@ -542,6 +640,26 @@ void g_web_set_connect_timeout(GWeb *web, guint timeout_ms)
 	web->connect_timeout_ms = timeout_ms;
 }
 
+/**
+ *  @brief
+ *    Set the TCP connection timeout.
+ *
+ *  This sets the TCP connection timeout, in milliseconds, for the
+ *  specified GWeb object.
+ *
+ *  param[in]  web             A pointer to the immutable GWeb object
+ *                             for which the TCP connection timeout is
+ *                             to be returned.
+ *
+ *  @returns
+ *    The TCP connection timeout, in milliseconds. A value of zero
+ *    ('0') indicates that no explicit connection timeout has been
+ *    set, leaving the timeout to the underlying operating system and
+ *    its network stack.
+ *
+ *  @sa g_web_set_connect_timeout
+ *
+ */
 guint g_web_get_connect_timeout(const GWeb *web)
 {
 	guint timeout_ms = 0;
@@ -1127,6 +1245,39 @@ static inline int bind_socket(int sk, int index, int family)
 	return err;
 }
 
+/**
+ *  @brief
+ *    Establish TCP connection for a GWeb session.
+ *
+ *  This attempts to establish a TCP connection for the specified GWeb
+ *  session with the session-specified address family, peer address,
+ *  and bound network interface.
+ *
+ *  @param[in,out]  session             A pointer to the mutable GWeb
+ *                                      session for which to establish
+ *                                      the session transport.
+ *  param[in]       connect_timeout_ms  The time, in milliseconds, for
+ *                                      the TCP connection timeout.
+ *                                      Connections that take longer
+ *                                      than this will be aborted. A
+ *                                      value of zero ('0') indicates
+ *                                      that no explicit connection
+ *                                      timeout will be used, leaving
+ *                                      the timeout to the underlying
+ *                                      operating system and its
+ *                                      network stack.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EIO     If a socket could not be created for the specified
+ *                    session address family, the socket could not be
+ *                    bound to the specified session network
+ *                    interface, or the socket could not connect to
+ *                    the specified session peer address.
+ *  @retval  -ENOMEM  If a GLib transport channle could not be created.
+ *
+ *  @sa close_session_transport
+ *
+ */
 static int connect_session_transport(struct web_session *session, guint connect_timeout_ms)
 {
 	GIOFlags flags;

--- a/gweb/gweb.c
+++ b/gweb/gweb.c
@@ -155,6 +155,29 @@ static void _debug(GWeb *web, const char *file, const char *caller,
 	va_end(ap);
 }
 
+static void close_session_transport(struct web_session *session)
+{
+	if (!session)
+		return;
+
+	debug(session->web, "closing session transport");
+
+	if (session->transport_watch > 0) {
+		g_source_remove(session->transport_watch);
+		session->transport_watch = 0;
+	}
+
+	if (session->send_watch > 0) {
+		g_source_remove(session->send_watch);
+		session->send_watch = 0;
+	}
+
+	if (session->transport_channel) {
+		g_io_channel_unref(session->transport_channel);
+		session->transport_channel = NULL;
+	}
+}
+
 static void free_session(struct web_session *session)
 {
 	GWeb *web;
@@ -172,14 +195,7 @@ static void free_session(struct web_session *session)
 	if (session->resolv_action > 0)
 		g_resolv_cancel_lookup(web->resolv, session->resolv_action);
 
-	if (session->transport_watch > 0)
-		g_source_remove(session->transport_watch);
-
-	if (session->send_watch > 0)
-		g_source_remove(session->send_watch);
-
-	if (session->transport_channel)
-		g_io_channel_unref(session->transport_channel);
+	close_session_transport(session);
 
 	g_free(session->result.last_key);
 

--- a/gweb/gweb.c
+++ b/gweb/gweb.c
@@ -125,6 +125,7 @@ struct _GWeb {
 	char *user_agent_profile;
 	char *http_version;
 	bool close_connection;
+	guint connect_timeout_ms;
 
 	GWebDebugFunc debug_func;
 	gpointer debug_data;
@@ -444,6 +445,29 @@ bool g_web_get_close_connection(GWeb *web)
 		return false;
 
 	return web->close_connection;
+}
+
+void g_web_set_connect_timeout(GWeb *web, guint timeout_ms)
+{
+	if (!web)
+		return;
+
+	debug(web, "timeout %ums", timeout_ms);
+
+	web->connect_timeout_ms = timeout_ms;
+}
+
+guint g_web_get_connect_timeout(const GWeb *web)
+{
+	guint timeout_ms = 0;
+
+	if (!web)
+		goto done;
+
+	timeout_ms = web->connect_timeout_ms;
+
+done:
+	return timeout_ms;
 }
 
 static inline void call_result_func(struct web_session *session, guint16 status)

--- a/gweb/gweb.h
+++ b/gweb/gweb.h
@@ -142,6 +142,9 @@ bool g_web_set_ua_profile(GWeb *web, const char *profile);
 
 bool g_web_set_http_version(GWeb *web, const char *version);
 
+void g_web_set_connect_timeout(GWeb *web, guint timeout_ms);
+guint g_web_get_connect_timeout(const GWeb *web);
+
 void g_web_set_close_connection(GWeb *web, bool enabled);
 bool g_web_get_close_connection(GWeb *web);
 

--- a/src/connman.h
+++ b/src/connman.h
@@ -531,6 +531,7 @@ int __connman_wispr_init(void);
 void __connman_wispr_cleanup(void);
 int __connman_wispr_start(struct connman_service *service,
 					enum connman_ipconfig_type type,
+					guint connect_timeout_ms,
 					__connman_wispr_cb_t callback);
 void __connman_wispr_stop(struct connman_service *service);
 

--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@
 #define DEFAULT_ONLINE_CHECK_IPV4_URL "http://ipv4.connman.net/online/status.html"
 #define DEFAULT_ONLINE_CHECK_IPV6_URL "http://ipv6.connman.net/online/status.html"
 
+#define DEFAULT_ONLINE_CHECK_CONNECT_TIMEOUT (0 * 1000)
 /*
  * We set the integer to 1 sec so that we have a chance to get
  * necessary IPv6 router advertisement messages that might have
@@ -110,6 +111,7 @@ static struct {
 	bool enable_online_to_ready_transition;
 	char *online_check_ipv4_url;
 	char *online_check_ipv6_url;
+    unsigned int online_check_connect_timeout_ms;
 	unsigned int online_check_initial_interval;
 	unsigned int online_check_max_interval;
 	char *online_check_interval_style;
@@ -141,6 +143,7 @@ static struct {
 	.enable_online_to_ready_transition = false,
 	.online_check_ipv4_url = NULL,
 	.online_check_ipv6_url = NULL,
+    .online_check_connect_timeout_ms = DEFAULT_ONLINE_CHECK_CONNECT_TIMEOUT,
 	.online_check_initial_interval = DEFAULT_ONLINE_CHECK_INITIAL_INTERVAL,
 	.online_check_max_interval = DEFAULT_ONLINE_CHECK_MAX_INTERVAL,
 	.online_check_interval_style = NULL,
@@ -172,6 +175,7 @@ static struct {
 #define CONF_ENABLE_ONLINE_TO_READY_TRANSITION "EnableOnlineToReadyTransition"
 #define CONF_ONLINE_CHECK_IPV4_URL      "OnlineCheckIPv4URL"
 #define CONF_ONLINE_CHECK_IPV6_URL      "OnlineCheckIPv6URL"
+#define CONF_ONLINE_CHECK_CONNECT_TIMEOUT "OnlineCheckConnectTimeout"
 #define CONF_ONLINE_CHECK_INITIAL_INTERVAL "OnlineCheckInitialInterval"
 #define CONF_ONLINE_CHECK_MAX_INTERVAL     "OnlineCheckMaxInterval"
 #define CONF_ONLINE_CHECK_INTERVAL_STYLE "OnlineCheckIntervalStyle"
@@ -204,6 +208,7 @@ static const char *supported_options[] = {
 	CONF_ENABLE_ONLINE_TO_READY_TRANSITION,
 	CONF_ONLINE_CHECK_IPV4_URL,
 	CONF_ONLINE_CHECK_IPV6_URL,
+	CONF_ONLINE_CHECK_CONNECT_TIMEOUT,
 	CONF_ONLINE_CHECK_INITIAL_INTERVAL,
 	CONF_ONLINE_CHECK_MAX_INTERVAL,
 	CONF_ONLINE_CHECK_INTERVAL_STYLE,
@@ -338,6 +343,7 @@ static void parse_config(GKeyFile *config)
 	char *string;
 	gsize len;
 	int integer;
+    double real;
 
 	if (!config) {
 		connman_settings.auto_connect =
@@ -527,6 +533,26 @@ static void parse_config(GKeyFile *config)
 	if (!error) {
 		connman_settings.enable_online_to_ready_transition = boolean;
 	}
+
+	g_clear_error(&error);
+
+	/* OnlineCheckConnecTimeout */
+
+	real = g_key_file_get_double(config, "General",
+			CONF_ONLINE_CHECK_CONNECT_TIMEOUT, &error);
+	if (!error) {
+		if (real < 0) {
+			connman_warn("Incorrect online check connect timeout %f",
+				real);
+			connman_settings.online_check_connect_timeout_ms =
+				DEFAULT_ONLINE_CHECK_CONNECT_TIMEOUT;
+		} else
+			connman_settings.online_check_connect_timeout_ms = real * 1000;
+	}
+
+	if (connman_settings.online_check_connect_timeout_ms)
+		connman_info("Online check connect timeout %ums",
+			connman_settings.online_check_connect_timeout_ms);
 
 	g_clear_error(&error);
 
@@ -885,6 +911,9 @@ bool connman_setting_get_bool(const char *key)
 
 unsigned int connman_setting_get_uint(const char *key)
 {
+	if (g_str_equal(key, CONF_ONLINE_CHECK_CONNECT_TIMEOUT))
+		return connman_settings.online_check_connect_timeout_ms;
+
 	if (g_str_equal(key, CONF_ONLINE_CHECK_INITIAL_INTERVAL))
 		return connman_settings.online_check_initial_interval;
 

--- a/src/main.conf
+++ b/src/main.conf
@@ -132,6 +132,15 @@
 # OnlineCheckIPv4URL= http://ipv4.connman.net/online/status.html
 # OnlineCheckIPv6URL= http://ipv6.connman.net/online/status.html
 
+# The time, in decimal seconds (for example, 12.3), to wait for a
+# successful TCP connection to the host associated with
+# "OnlineCheckIPv4URL" or "OnlineCheckIPv6URL". Connections that take
+# longer than "OnlineCheckConnectTimeout" will be aborted. The default
+# value is zero ('0') which indicates that no explicit connection
+# timeout will be used, leaving the timeout to the underlying operating
+# system and network stack.
+# OnlineCheckConnectTimeout=0
+
 # Range of intervals between two online check requests.
 # Please refer to the README for more detailed information.
 # Default values are 1 and 12 respectively.

--- a/src/service.c
+++ b/src/service.c
@@ -58,6 +58,7 @@ static unsigned int vpn_autoconnect_id = 0;
 static struct connman_service *current_default = NULL;
 static bool services_dirty = false;
 static bool enable_online_to_ready_transition = false;
+static unsigned int online_check_connect_timeout_ms = 0;
 static unsigned int online_check_initial_interval = 0;
 static unsigned int online_check_max_interval = 0;
 static const char *online_check_timeout_interval_style = NULL;
@@ -1700,7 +1701,8 @@ static void redo_wispr(struct connman_service *service,
 		service, connman_service_get_identifier(service),
 		type, __connman_ipconfig_type2string(type));
 
-	__connman_wispr_start(service, type, complete_online_check);
+	__connman_wispr_start(service, type,
+			online_check_connect_timeout_ms, complete_online_check);
 
 	// Release the reference to the service taken when
 	// g_timeout_add_seconds was invoked with the callback
@@ -2011,7 +2013,8 @@ void __connman_service_wispr_start(struct connman_service *service,
 		service->online_check_interval_ipv6 =
 					online_check_initial_interval;
 
-	__connman_wispr_start(service, type, complete_online_check);
+	__connman_wispr_start(service, type,
+			online_check_connect_timeout_ms, complete_online_check);
 }
 
 static void address_updated(struct connman_service *service,
@@ -8495,6 +8498,9 @@ int __connman_service_init(void)
 		online_check_timeout_compute_func = online_check_timeout_compute_fibonacci;
 	else
 		online_check_timeout_compute_func = online_check_timeout_compute_geometric;
+
+	online_check_connect_timeout_ms =
+		connman_setting_get_uint("OnlineCheckConnectTimeout");
 
 	online_check_initial_interval =
 		connman_setting_get_uint("OnlineCheckInitialInterval");

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1071,6 +1071,49 @@ done:
 	return err;
 }
 
+/**
+ *  @brief
+ *    Start a HTTP-based Internet reachability check for the specified
+ *    network service IP configuration type.
+ *
+ *  This attempts to start a HTTP-based Internet reachability check
+ *  for the specified network service IP configuration type with the
+ *  provided connection timeout and completion callback.
+ *
+ *  @param[in,out]  service             A pointer to the mutable network
+ *                                      service for which to start the
+ *                                      reachability check.
+ *  @param[in]      type                The IP configuration type for
+ *                                      which the reachability check
+ *                                      is to be started.
+ *  param[in]       connect_timeout_ms  The time, in milliseconds, for
+ *                                      the TCP connection timeout.
+ *                                      Connections that take longer
+ *                                      than this will be aborted. A
+ *                                      value of zero ('0') indicates
+ *                                      that no explicit connection
+ *                                      timeout will be used, leaving
+ *                                      the timeout to the underlying
+ *                                      operating system and its
+ *                                      network stack.
+ *  @param[in]      callback            The callback to be invoked when
+ *                                      the reachability check
+ *                                      terminates, either on failure
+ *                                      or success.
+ *
+ *  @retval  0            If successful.
+ *  @retval  -EINVAL      If the reachability check subsystem is not
+ *                        properly initialized, @a callback is null,
+ *                        or if the network interface index associated
+ *                        with @a service is invalid.
+ *  @retval  -EOPNOTSUPP  If a reachability check is not supported for
+ *                        the network service technology type.
+ *  @retval  -ENOMEM      If resources could not be allocated for the
+ *                        reachability check.
+ *
+ *  @sa __connman_wispr_stop
+ *
+ */
 int __connman_wispr_start(struct connman_service *service,
 					enum connman_ipconfig_type type,
 					guint connect_timeout_ms,


### PR DESCRIPTION
This addresses #72 by:

1. Introducing a new `OnlineCheckConnectTimeout` setting.
2. Adding to GWeb a TCP connection timeout member, getter, and setter.
3. Leveraging both (1) and (2) in the service and WISPr code to pass (1) to (2) when  so configured.

If the GWeb TCP connect timeout is greater than zero, a GLib connection timeout timer and callback are added to the session such that, when they expire, the in flight TCP connection is aborted and the session closure function invoked with `GWEB_HTTP_STATUS_CODE_REQUEST_TIMEOUT`.
    
A TCP connect timeout of zero (`0`) indicates that no explicit connection timeout will be used and no timer or callback added to the session, leaving the timeout to the underlying operating system and its network stack.