### PR TITLE
Address Redundant IPv4 'Online' Reachability Check through Full Cross-module Cancellation

### DIFF
--- a/gweb/gweb.c
+++ b/gweb/gweb.c
@@ -415,6 +415,9 @@ GWeb *g_web_ref(GWeb *web)
 	if (!web)
 		return NULL;
 
+	debug(web, "ref %d",
+		web->ref_count + 1);
+
 	__sync_fetch_and_add(&web->ref_count, 1);
 
 	return web;
@@ -424,6 +427,9 @@ void g_web_unref(GWeb *web)
 {
 	if (!web)
 		return;
+
+	debug(web, "ref %d",
+		web->ref_count - 1);
 
 	if (__sync_fetch_and_sub(&web->ref_count, 1) != 1)
 		return;

--- a/gweb/gweb.c
+++ b/gweb/gweb.c
@@ -2274,23 +2274,31 @@ static bool is_ip_address(const char *host)
 static guint do_request(GWeb *web, const char *url,
 				const char *type, GWebInputFunc input,
 				int fd, gsize length, GWebResultFunc func,
-				GWebRouteFunc route, gpointer user_data)
+				GWebRouteFunc route, gpointer user_data,
+				int *err)
 {
 	struct web_session *session;
 	const gchar *host;
+	int request_id = 0;
+	int status = 0;
 
-	if (!web || !url)
-		return 0;
+	if (!web || !url) {
+		status = -EINVAL;
+		goto done;
+	}
 
 	debug(web, "request %s", url);
 
 	session = g_try_new0(struct web_session, 1);
-	if (!session)
-		return 0;
+	if (!session) {
+		status = -ENOMEM;
+		goto done;
+	}
 
-	if (parse_request_and_proxy_urls(session, url, web->proxy) < 0) {
+	status = parse_request_and_proxy_urls(session, url, web->proxy);
+	if (status < 0) {
 		free_session(session);
-		return 0;
+		goto done;
 	}
 
 	debug(web, "proxy host %s", session->address);
@@ -2318,14 +2326,16 @@ static guint do_request(GWeb *web, const char *url,
 	session->receive_buffer = g_try_malloc(DEFAULT_BUFFER_SIZE);
 	if (!session->receive_buffer) {
 		free_session(session);
-		return 0;
+		status = -ENOMEM;
+		goto done;
 	}
 
 	session->result.headers = g_hash_table_new_full(g_str_hash, g_str_equal,
 							g_free, g_free);
 	if (!session->result.headers) {
 		free_session(session);
-		return 0;
+		status = -ENOMEM;
+		goto done;
 	}
 
 	session->receive_space = DEFAULT_BUFFER_SIZE;
@@ -2344,33 +2354,46 @@ static guint do_request(GWeb *web, const char *url,
 	} else {
 		session->resolv_action = g_resolv_lookup_hostname(web->resolv,
 					host, resolv_result, session);
-		if (session->resolv_action == 0) {
+		if (session->resolv_action <= 0) {
 			free_session(session);
-			return 0;
+			status = session->resolv_action < 0 ?
+						session->resolv_action :
+						-ENOENT;
+			goto done;
 		}
 	}
 
 	web->session_list = g_list_append(web->session_list, session);
 
-	return web->next_query_id++;
+	request_id = web->next_query_id++;
+
+done:
+	if (err)
+		*err = status;
+
+	return request_id;
 }
 
 guint g_web_request_get(GWeb *web, const char *url, GWebResultFunc func,
-		GWebRouteFunc route, gpointer user_data)
+		GWebRouteFunc route, gpointer user_data, int *err)
 {
-	return do_request(web, url, NULL, NULL, -1, 0, func, route, user_data);
+	return do_request(web, url, NULL, NULL, -1, 0,
+		func, route, user_data, err);
 }
 
 guint g_web_request_post(GWeb *web, const char *url,
 				const char *type, GWebInputFunc input,
-				GWebResultFunc func, gpointer user_data)
+				GWebResultFunc func, gpointer user_data,
+				int *err)
 {
-	return do_request(web, url, type, input, -1, 0, func, NULL, user_data);
+	return do_request(web, url, type, input, -1, 0,
+		func, NULL, user_data, err);
 }
 
 guint g_web_request_post_file(GWeb *web, const char *url,
 				const char *type, const char *file,
-				GWebResultFunc func, gpointer user_data)
+				GWebResultFunc func, gpointer user_data,
+				int *err)
 {
 	struct stat st;
 	int fd;
@@ -2384,7 +2407,7 @@ guint g_web_request_post_file(GWeb *web, const char *url,
 		return 0;
 
 	ret = do_request(web, url, type, NULL, fd, st.st_size, func, NULL,
-			user_data);
+			user_data, err);
 	if (ret == 0)
 		close(fd);
 

--- a/gweb/gweb.h
+++ b/gweb/gweb.h
@@ -150,13 +150,15 @@ bool g_web_get_close_connection(GWeb *web);
 
 guint g_web_request_get(GWeb *web, const char *url,
 				GWebResultFunc func, GWebRouteFunc route,
-				gpointer user_data);
+				gpointer user_data, int *err);
 guint g_web_request_post(GWeb *web, const char *url,
 				const char *type, GWebInputFunc input,
-				GWebResultFunc func, gpointer user_data);
+				GWebResultFunc func, gpointer user_data,
+				int *err);
 guint g_web_request_post_file(GWeb *web, const char *url,
 				const char *type, const char *file,
-				GWebResultFunc func, gpointer user_data);
+				GWebResultFunc func, gpointer user_data,
+				int *err);
 
 bool g_web_cancel_request(GWeb *web, guint id);
 

--- a/src/6to4.c
+++ b/src/6to4.c
@@ -318,7 +318,7 @@ static void tun_newlink(unsigned flags, unsigned change, void *user_data)
 			g_web_set_debug(web, web_debug, "6to4");
 
 		web_request_id = g_web_request_get(web, STATUS_URL,
-				web_result, NULL,  NULL);
+				web_result, NULL,  NULL, NULL);
 
 		newlink_timeout(NULL);
 	}

--- a/src/connman.h
+++ b/src/connman.h
@@ -534,6 +534,8 @@ int __connman_wispr_start(struct connman_service *service,
 					enum connman_ipconfig_type type,
 					guint connect_timeout_ms,
 					__connman_wispr_cb_t callback);
+int __connman_wispr_cancel(struct connman_service *service,
+					enum connman_ipconfig_type type);
 void __connman_wispr_stop(struct connman_service *service);
 
 #include <connman/technology.h>

--- a/src/connman.h
+++ b/src/connman.h
@@ -525,7 +525,8 @@ void __connman_wpad_stop(struct connman_service *service);
 
 typedef void (*__connman_wispr_cb_t) (struct connman_service *service,
 				enum connman_ipconfig_type type,
-				bool success);
+				bool success,
+				int err);
 
 int __connman_wispr_init(void);
 void __connman_wispr_cleanup(void);

--- a/src/service.c
+++ b/src/service.c
@@ -1590,11 +1590,23 @@ static void cancel_online_check(struct connman_service *service)
 	if (service->online_timeout_ipv4) {
 		g_source_remove(service->online_timeout_ipv4);
 		service->online_timeout_ipv4 = 0;
+
+		/*
+		 * This balances the retained referece made when
+		 * g_timeout_add_seconds was called to schedule this
+		 * now-cancelled scheduled online check.
+		 */
 		connman_service_unref(service);
 	}
 	if (service->online_timeout_ipv6) {
 		g_source_remove(service->online_timeout_ipv6);
 		service->online_timeout_ipv6 = 0;
+
+		/*
+		 * This balances the retained referece made when
+		 * g_timeout_add_seconds was called to schedule this
+		 * now-cancelled scheduled online check.
+		 */
 		connman_service_unref(service);
 	}
 }

--- a/src/service.c
+++ b/src/service.c
@@ -163,7 +163,8 @@ static void vpn_auto_connect(void);
 static void trigger_autoconnect(struct connman_service *service);
 static void complete_online_check(struct connman_service *service,
 					enum connman_ipconfig_type type,
-					bool success);
+					bool success,
+					int err);
 static bool service_downgrade_online_state(struct connman_service *service);
 
 struct find_data {
@@ -1902,6 +1903,11 @@ static void reschedule_online_check(struct connman_service *service,
  *                           check.
  *  @param[in]      success  A Boolean indicating whether the previously-
  *                           requested online check was successful.
+ *  @param[in]      err      The error status associated with previously-
+ *                           requested online check. This is expected
+ *                           to be zero ('0') if @a success is @a true
+ *                           and less than zero ('< 0') if @a success
+ *                           is @a false.
  *
  *  @sa cancel_online_check
  *  @sa start_online_check
@@ -1911,16 +1917,17 @@ static void reschedule_online_check(struct connman_service *service,
  */
 static void complete_online_check(struct connman_service *service,
 					enum connman_ipconfig_type type,
-					bool success)
+					bool success,
+					int err)
 {
 	unsigned int *interval;
 	guint *timeout;
 
-	DBG("service %p (%s) type %d (%s) success %d\n",
+	DBG("service %p (%s) type %d (%s) success %d err %d (%s)\n",
 		service,
 		connman_service_get_identifier(service),
 		type, __connman_ipconfig_type2string(type),
-		success);
+		success, err, strerror(-err));
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4) {
 		interval = &service->online_check_interval_ipv4;

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1072,6 +1072,25 @@ done:
 	return err;
 }
 
+/**
+ *  @brief
+ *    Return whether WISPr requests / HTTP-based Internet reachability
+ *    checks are supported.
+ *
+ *  This determines whether WISPr requests / HTTP-based Internet
+ *  reachability check are supported for the specified network service
+ *  based on its associated technology type.
+ *
+ *  @param[in]  service  A pointer to the immutable network service
+ *                       for which to check WISPr requests / HTTP-based
+ *                       Internet reachability check support.
+ *
+ *  @returns
+ *    True if the network service technology type supports WISPr
+ *    requests / HTTP-based Internet reachability checks; otherwise,
+ *    false.
+ *
+ */
 static bool is_wispr_supported(const struct connman_service *service)
 {
 	if (!service)

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1340,6 +1340,61 @@ free_wp:
 	return err;
 }
 
+int __connman_wispr_cancel(struct connman_service *service,
+					enum connman_ipconfig_type type)
+{
+	struct connman_wispr_portal_context *wp_context = NULL;
+	struct connman_wispr_portal *wispr_portal = NULL;
+	int index;
+
+	DBG("service %p (%s) type %d (%s)",
+		service, connman_service_get_identifier(service),
+		type, __connman_ipconfig_type2string(type));
+
+	if (!is_wispr_supported(service))
+		return -EOPNOTSUPP;
+
+	index = __connman_service_get_index(service);
+	if (index < 0)
+		return -EINVAL;
+
+	DBG("index %d", index);
+
+	if (!wispr_portal_hash)
+		return -ENOENT;
+
+	wispr_portal = g_hash_table_lookup(wispr_portal_hash,
+					GINT_TO_POINTER(index));
+
+	DBG("wispr_portal %p", wispr_portal);
+
+	if (!wispr_portal)
+		return -ENOENT;
+
+	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
+		wp_context = wispr_portal->ipv4_context;
+	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
+		wp_context = wispr_portal->ipv6_context;
+	else
+		return -EINVAL;
+
+	DBG("wp_context %p", wp_context);
+
+	if (!wp_context)
+		return -ENOENT;
+
+	cancel_connman_wispr_portal_context(wp_context);
+
+	wp_context->cb(wp_context->service,
+			wp_context->type,
+			false,
+			-ECANCELED);
+
+	wispr_portal_context_unref(wp_context);
+
+	return 0;
+}
+
 /**
  *  @brief
  *    Stop all HTTP-based Internet reachability checks for the specified

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -564,7 +564,7 @@ static void portal_manage_success_status(GWebResult *result,
 				&str))
 		connman_info("Client-Timezone: %s", str);
 
-	wp_context->cb(service, type, true);
+	wp_context->cb(service, type, true, 0);
 }
 
 static bool wispr_route_request(const char *address, int ai_family,
@@ -618,6 +618,8 @@ static bool wispr_route_request(const char *address, int ai_family,
 static void wispr_portal_request_portal(
 		struct connman_wispr_portal_context *wp_context)
 {
+	int err = 0;
+
 	DBG("wispr/portal context %p service %p (%s) type %d (%s)",
 		wp_context,
 		wp_context->service,
@@ -634,10 +636,13 @@ static void wispr_portal_request_portal(
 					wp_context->status_url,
 					wispr_portal_web_result,
 					wispr_route_request,
-					wp_context, NULL);
+					wp_context, &err);
 
 	if (wp_context->request_id == 0) {
-		wp_context->cb(wp_context->service, wp_context->type, false);
+		wp_context->cb(wp_context->service,
+						wp_context->type,
+						false,
+						err);
 		wispr_portal_error(wp_context);
 		wispr_portal_context_unref(wp_context);
 	}
@@ -910,11 +915,26 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 
 		goto done;
 	case GWEB_HTTP_STATUS_CODE_BAD_REQUEST:
-	case GWEB_HTTP_STATUS_CODE_NOT_FOUND:
-	case GWEB_HTTP_STATUS_CODE_REQUEST_TIMEOUT:
-		wp_context->cb(wp_context->service, wp_context->type, false);
-
+		wp_context->cb(wp_context->service,
+				wp_context->type,
+				false,
+				-EINVAL);
 		break;
+
+	case GWEB_HTTP_STATUS_CODE_NOT_FOUND:
+		wp_context->cb(wp_context->service,
+				wp_context->type,
+				false,
+				-ENOENT);
+		break;
+
+	case GWEB_HTTP_STATUS_CODE_REQUEST_TIMEOUT:
+		wp_context->cb(wp_context->service,
+				wp_context->type,
+				false,
+				-ETIMEDOUT);
+		break;
+
 	case GWEB_HTTP_STATUS_CODE_HTTP_VERSION_NOT_SUPPORTED:
 		wispr_portal_context_ref(wp_context);
 		__connman_agent_request_browser(wp_context->service,
@@ -977,7 +997,10 @@ static void proxy_callback(const char *proxy, void *user_data)
 	if (!proxy) {
 		DBG("no valid proxy");
 
-		wp_context->cb(wp_context->service, wp_context->type, false);
+		wp_context->cb(wp_context->service,
+				wp_context->type,
+				false,
+				-EINVAL);
 
 		return;
 	}
@@ -1311,7 +1334,7 @@ int __connman_wispr_start(struct connman_service *service,
 	return 0;
 
 free_wp:
-	wp_context->cb(wp_context->service, wp_context->type, false);
+	wp_context->cb(wp_context->service, wp_context->type, false, err);
 
 	g_hash_table_remove(wispr_portal_hash, GINT_TO_POINTER(index));
 	return err;

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1072,6 +1072,27 @@ done:
 	return err;
 }
 
+static bool is_wispr_supported(const struct connman_service *service)
+{
+	if (!service)
+		return false;
+
+	switch (connman_service_get_type(service)) {
+	case CONNMAN_SERVICE_TYPE_ETHERNET:
+	case CONNMAN_SERVICE_TYPE_WIFI:
+	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
+	case CONNMAN_SERVICE_TYPE_CELLULAR:
+	case CONNMAN_SERVICE_TYPE_GADGET:
+		return true;
+	case CONNMAN_SERVICE_TYPE_UNKNOWN:
+	case CONNMAN_SERVICE_TYPE_SYSTEM:
+	case CONNMAN_SERVICE_TYPE_GPS:
+	case CONNMAN_SERVICE_TYPE_VPN:
+	case CONNMAN_SERVICE_TYPE_P2P:
+		return false;
+	}
+}
+
 /**
  *  @brief
  *    Start a HTTP-based Internet reachability check for the specified
@@ -1132,20 +1153,8 @@ int __connman_wispr_start(struct connman_service *service,
 	if (!wispr_portal_hash || !callback)
 		return -EINVAL;
 
-	switch (connman_service_get_type(service)) {
-	case CONNMAN_SERVICE_TYPE_ETHERNET:
-	case CONNMAN_SERVICE_TYPE_WIFI:
-	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
-	case CONNMAN_SERVICE_TYPE_CELLULAR:
-	case CONNMAN_SERVICE_TYPE_GADGET:
-		break;
-	case CONNMAN_SERVICE_TYPE_UNKNOWN:
-	case CONNMAN_SERVICE_TYPE_SYSTEM:
-	case CONNMAN_SERVICE_TYPE_GPS:
-	case CONNMAN_SERVICE_TYPE_VPN:
-	case CONNMAN_SERVICE_TYPE_P2P:
+	if (!is_wispr_supported(service))
 		return -EOPNOTSUPP;
-	}
 
 	index = __connman_service_get_index(service);
 	if (index < 0)

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -166,6 +166,24 @@ static void free_wispr_routes(struct connman_wispr_portal_context *wp_context)
 	}
 }
 
+/**
+ *  @brief
+ *    Cancel a WISPr/portal request.
+ *
+ *  This attempts to cancel any outstanding request associated with
+ *  the specified WISPr/portal context. This deallocates any resources
+ *  associated with the context, except for the context itself which
+ *  requires invoking #free_connman_wispr_portal_context.
+ *
+ *  @param[in,out]  wp_context  A pointer to the mutable WISPr/portal
+ *                              context for which to cancel an outstanding
+ *                              request, whether a reachability check
+ *                              or otherwise.
+ *
+ *  @sa create_connman_wispr_portal_context
+ *  @sa free_connman_wispr_portal_context
+ *
+ */
 static void cancel_connman_wispr_portal_context(
 		struct connman_wispr_portal_context *wp_context)
 {

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -968,6 +968,46 @@ static gboolean no_proxy_callback(gpointer user_data)
 	return FALSE;
 }
 
+/**
+ *  @brief
+ *    Start a WISPr / portal detection request / HTTP-based Internet
+ *    reachability check for the specified WISPr / portal context.
+ *
+ *  This attempts to start a WISPr / portal detection request /
+ *  HTTP-based Internet reachability check for the network service IP
+ *  configuration type associated with the provided WISPr / portal
+ *  context with the provided connection timeout.
+ *
+ *  @param[in,out]  wp_context          A pointer to the mutable WISPr
+ *                                      / portal context to supporting
+ *                                      running the WISPr request /
+ *                                      HTTP-based Internet
+ *                                      reachability check.
+ *  param[in]       connect_timeout_ms  The time, in milliseconds, for
+ *                                      the TCP connection timeout.
+ *                                      Connections that take longer
+ *                                      than this will be aborted. A
+ *                                      value of zero ('0') indicates
+ *                                      that no explicit connection
+ *                                      timeout will be used, leaving
+ *                                      the timeout to the underlying
+ *                                      operating system and its
+ *                                      network stack.
+ *
+ *  @retval  0        If the WISPr request / HTTP-based Internet
+ *                    reachability check was successfully queued.
+ *  @retval  -EINVAL  If the network interface or network interface
+ *                    index associated with @a wp_context->service is
+ *                    invalid, if @a wp_context->service has no name
+ *                    servers, or if a proxy could not be successfully
+ *                    associated with @a wp_context->service.
+ *  @retval  -ENOMEM  If a GWeb instance could not be allocated for
+ *                    the WISPr request / HTTP-based Internet
+ *                    reachability check.
+ *
+ *  @sa __connman_wispr_start
+ *
+ */
 static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context,
 						guint connect_timeout_ms)
 {

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1340,6 +1340,41 @@ free_wp:
 	return err;
 }
 
+/**
+ *  @brief
+ *    Cancel a HTTP-based Internet reachability check for the specified
+ *    network service IP configuration type.
+ *
+ *  This attempts to cancel a HTTP-based Internet reachability check
+ *  for the specified network service IP configuration type.
+ *
+ *  If a matching HTTP-based Internet reachability check is found, the
+ *  original callback specified with #__connman_wispr_start will be
+ *  invoked with a success value of zero ('0') or false and an error
+ *  value of -ECANCELED.
+ *
+ *  @param[in,out]  service             A pointer to the mutable network
+ *                                      service for which to cancel the
+ *                                      reachability check.
+ *  @param[in]      type                The IP configuration type for
+ *                                      which the reachability check
+ *                                      is to be cancelled.
+ *
+ *  @retval  0            If a matching HTTP-based Internet reachability
+ *                        check was successfully cancelled.
+ *  @retval  -EINVAL      If the IP configuration type is not X or Y or
+ *                        if the network interface index associated
+ *                        with @a service is invalid.
+ *  @retval  -ENOENT      If a matching HTTP-based Internet reachability
+ *                        check could not be found.
+ *  @retval  -EOPNOTSUPP  If HTTP-based Internet reachability checks are
+ *                        not supported for the technology type
+ *                        associated with @a service.
+ *
+ *  @sa __connman_wispr_start
+ *  @sa __connman_wispr_stop
+ *
+ */
 int __connman_wispr_cancel(struct connman_service *service,
 					enum connman_ipconfig_type type)
 {

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -158,7 +158,10 @@ static void free_wispr_routes(struct connman_wispr_portal_context *wp_context)
 		}
 
 		g_free(route->address);
+		route->address = NULL;
+
 		g_free(route);
+		wp_context->route_list->data = NULL;
 
 		wp_context->route_list =
 			g_slist_delete_link(wp_context->route_list,

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1267,6 +1267,22 @@ free_wp:
 	return err;
 }
 
+/**
+ *  @brief
+ *    Stop all HTTP-based Internet reachability checks for the specified
+ *    network service.
+ *
+ *  This attempts to stop all HTTP-based Internet reachability checks
+ *  for the specified network service.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           for which to stop all reachability
+ *                           checks.
+ *
+ *  @sa __connman_wispr_start
+ *  @sa __connman_wispr_cancel
+ *
+ */
 void __connman_wispr_stop(struct connman_service *service)
 {
 	struct connman_wispr_portal *wispr_portal;

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -634,7 +634,7 @@ static void wispr_portal_request_portal(
 					wp_context->status_url,
 					wispr_portal_web_result,
 					wispr_route_request,
-					wp_context);
+					wp_context, NULL);
 
 	if (wp_context->request_id == 0) {
 		wp_context->cb(wp_context->service, wp_context->type, false);
@@ -751,7 +751,7 @@ static void wispr_portal_request_wispr_login(struct connman_service *service,
 					wp_context->wispr_msg.login_url,
 					"application/x-www-form-urlencoded",
 					wispr_input, wispr_portal_web_result,
-					wp_context);
+					wp_context, NULL);
 
 	connman_wispr_message_init(&wp_context->wispr_msg);
 }
@@ -906,7 +906,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
 		wispr_portal_context_ref(wp_context);
 		wp_context->request_id = g_web_request_get(wp_context->web,
 				redirect, wispr_portal_web_result,
-				wispr_route_request, wp_context);
+				wispr_route_request, wp_context, NULL);
 
 		goto done;
 	case GWEB_HTTP_STATUS_CODE_BAD_REQUEST:

--- a/tools/web-test.c
+++ b/tools/web-test.c
@@ -150,7 +150,8 @@ int main(int argc, char *argv[])
 
 	timer = g_timer_new();
 
-	if (g_web_request_get(web, argv[1], web_result, NULL,  NULL) == 0) {
+	if (g_web_request_get(web, argv[1], web_result,
+			NULL, NULL, NULL) == 0) {
 		fprintf(stderr, "Failed to start request\n");
 		return 1;
 	}

--- a/tools/wispr.c
+++ b/tools/wispr.c
@@ -531,7 +531,7 @@ static bool wispr_result(GWebResult *result, gpointer user_data)
 		printf("\n");
 
 		wispr->request = g_web_request_get(wispr->web, redirect,
-				wispr_result, wispr_route, wispr);
+				wispr_result, wispr_route, wispr, NULL);
 
 		return false;
 	}
@@ -591,7 +591,7 @@ static bool wispr_result(GWebResult *result, gpointer user_data)
 		printf("\n");
 
 		wispr->request = g_web_request_get(wispr->web, redirect,
-				wispr_result, NULL, wispr);
+				wispr_result, NULL, wispr, NULL);
 
 		return false;
 	}
@@ -608,7 +608,7 @@ static gboolean execute_login(gpointer user_data)
 
 	wispr->request = g_web_request_post(wispr->web, wispr->msg.login_url,
 					"application/x-www-form-urlencoded",
-					wispr_input, wispr_result, wispr);
+					wispr_input, wispr_result, wispr, NULL);
 
 	wispr_msg_init(&wispr->msg);
 
@@ -694,7 +694,7 @@ int main(int argc, char *argv[])
 						parser_callback, &wispr);
 
 	wispr.request = g_web_request_get(wispr.web, option_url,
-			wispr_result, wispr_route, &wispr);
+			wispr_result, wispr_route, &wispr, NULL);
 
 	if (wispr.request == 0) {
 		fprintf(stderr, "Failed to start request\n");


### PR DESCRIPTION
This addresses #74 by introducing and leveraging `__connman_wispr_cancel` in `cancel_online_check` to ensure that a pending or in-flight WISPr portal detection request or an "online" HTTP-based Internet reachability check is canceled not only in the _service_ module but in the _WISPr_ module as well.
    
This prevents two concurrent, outstanding, and redundant IPv4 WISPr requests from being in-flight when `EnableOnlineCheck` is asserted.
    
Prior to these changes, this redundancy was set in motion by:
    
1. The two back-to-back IPv4 probes get triggered by both of the following paths:
    1. Triggered from `default_changed` and `start_wispr_if_connected`. This is the newer path, chronologically, in the code base.
    2. Triggered from `service_ip_bound`, `address_updated`, and `start_online_check`. This is the older path, chronologically, in the code base.
2. With the following commits addressed:    
    1. 812e171 ("Close three `__connman_wisp_start` failure closure holes.")
        1. With this fix alone, at minimum, the first probe above (1) would have resulted, eventually in a failure closure with `complete_online_check`.
    2. 5f95851 ("wispr: Avoid `connman_proxy_lookup` call for `UNKNOWN` proxy method.") fixed, the first IPv4 probe from (1) no longer "falls down a 'hole'" and gets lost (closure- and accounting-wise).
        1. With this fix, the first IPv4 probe is no longer a complete throwaway--it actually succeeds. However, since it does so, it becomes the first of the two redundant IPv4 checks.

By employing `__connman_wispr_cancel`, `cancel_online_check` quells the first IPv4 check triggered from `default_changed` and `start_wispr_if_connected` and replaces it, fully (in **both** the _service_ and _WISpr_ modules), with the second IPv4 check triggered from `service_ip_bound`, `address_updated`, and `start_online_check`.
