### PR TITLE
service: Leverage 'connman_service_set_proxy_method'.

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1473,8 +1473,7 @@ static bool check_proxy_setup(struct connman_service *service)
 		return true;
 
 	if (__connman_wpad_start(service) < 0) {
-		service->proxy = CONNMAN_SERVICE_PROXY_METHOD_DIRECT;
-		__connman_notifier_proxy_changed(service);
+		connman_service_set_proxy_method(service, CONNMAN_SERVICE_PROXY_METHOD_DIRECT);
 		return true;
 	}
 


### PR DESCRIPTION
Previously, inside `check_proxy_method`, if Web Proxy Auto Discovery (WPAD) failed for any reason the code would explicitly manipulate the `proxy` field of the service object and then invoke `__connman_notifier_proxy_changed`.

However, when the proxy method is `CONNMAN_SERVICE_PROXY_METHOD_DIRECT`, which is the case in `check_proxy_method`, this is 2/3 the implementation of what `connman_service_set_proxy_method` already implements. The 1/3  difference is that `connman_service_set_proxy_method` calls `proxy_changed`.

Consequently, since there does not seem to be a well-documented or compelling reason to avoid the call to `proxy_changed`, simply leverage and call `connman_service_set_proxy_method` from `check_proxy_method` to set the service proxy method to `CONNMAN_SERVICE_PROXY_METHOD_DIRECT` when WPAD fails.