### PR TITLE
service: Make DBG in '__connman_service_ipconfig_indicate_state' Consistent

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -7205,11 +7205,11 @@ int __connman_service_ipconfig_indicate_state(struct connman_service *service,
 	if (old_state == new_state)
 		return -EALREADY;
 
-	DBG("service %p (%s) old state %d (%s) new state %d (%s) type %d (%s)",
+	DBG("service %p (%s) type %d (%s) old state %d (%s) new state %d (%s)",
 		service, connman_service_get_identifier(service),
+		type, __connman_ipconfig_type2string(type),
 		old_state, state2string(old_state),
-		new_state, state2string(new_state),
-		type, __connman_ipconfig_type2string(type));
+		new_state, state2string(new_state));
 
 	switch (new_state) {
 	case CONNMAN_SERVICE_STATE_UNKNOWN:


### PR DESCRIPTION
This makes the `DBG` statement in `__connman_service_ipconfig_indicate_state` consistent in format of `service <service_pointer> (<service_name>) type <ipconfig_type> (<ipconfig_type_name>)` with that of other `DBG` statements in the module.

This makes at-a-glance, columnar correlation and comparison of service activities easier.