### PR TITLE
service: Const-qualify 'connman_service_get_interface'.

### DIFF
--- a/include/service.h
+++ b/include/service.h
@@ -116,7 +116,7 @@ void connman_service_unref_debug(struct connman_service *service,
 
 enum connman_service_type connman_service_get_type(const struct connman_service *service);
 enum connman_service_state connman_service_get_state(const struct connman_service *service);
-char *connman_service_get_interface(struct connman_service *service);
+char *connman_service_get_interface(const struct connman_service *service);
 
 const char *connman_service_get_identifier(const struct connman_service *service);
 const char *connman_service_get_domainname(const struct connman_service *service);

--- a/src/service.c
+++ b/src/service.c
@@ -6275,7 +6275,7 @@ enum connman_service_type connman_service_get_type(const struct connman_service 
  *
  * Get network interface of service
  */
-char *connman_service_get_interface(struct connman_service *service)
+char *connman_service_get_interface(const struct connman_service *service)
 {
 	int index;
 

--- a/tools/iptables-unit.c
+++ b/tools/iptables-unit.c
@@ -624,7 +624,7 @@ struct connman_service {
 	char *dummy;
 };
 
-char *connman_service_get_interface(struct connman_service *service)
+char *connman_service_get_interface(const struct connman_service *service)
 {
 	return "eth0";
 }


### PR DESCRIPTION
Const-qualify the network service argument to `connman_service_get_interface` to make it clear to the compiler, static analyzers, and human readers that the function is strictly a getter with no network service mutation side effects.