### PR TITLE
service: Add and Leverage 'clear_error'

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -4690,6 +4690,24 @@ static DBusMessage *set_property(DBusConnection *conn,
 	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
 }
 
+/**
+ *  @brief
+ *    Set the specified network service "Error" property.
+ *
+ *  This sets the specified network service "Error" property to the
+ *  provided value.
+ *
+ *  @note
+ *    This function results in a D-Bus property changed signal for the
+ *    network service "Error" property.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           for which to set the "Error" property.
+ *  @param[in]      error    The error value to set.
+ *
+ *  @sa clear_error
+ *
+ */
 static void set_error(struct connman_service *service,
 					enum connman_service_error error)
 {
@@ -4716,6 +4734,25 @@ static void set_error(struct connman_service *service,
 				DBUS_TYPE_STRING, &str);
 }
 
+/**
+ *  @brief
+ *    Clear or reset the specified network service "Error" property.
+ *
+ *  This sets the specified network service "Error" property to the
+ *  initialization value of #CONNMAN_SERVICE_ERROR_UNKNOWN,
+ *  effectively clearing or resetting the property.
+ *
+ *  @note
+ *    This function results in a D-Bus property changed signal for the
+ *    network service "Error" property.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           for which to clear or reset the "Error"
+ *                           property.
+ *
+ *  @sa set_error
+ *
+ */
 static void clear_error(struct connman_service *service)
 {
 	set_error(service, CONNMAN_SERVICE_ERROR_UNKNOWN);

--- a/src/service.c
+++ b/src/service.c
@@ -193,6 +193,7 @@ static void complete_online_check(struct connman_service *service,
 					int err);
 static bool service_downgrade_online_state(struct connman_service *service);
 static bool connman_service_is_default(const struct connman_service *service);
+static void clear_error(struct connman_service *service);
 
 struct find_data {
 	const char *path;
@@ -4033,7 +4034,7 @@ int __connman_service_set_passphrase(struct connman_service *service,
 
 	if (service->hidden_service &&
 			service->error == CONNMAN_SERVICE_ERROR_INVALID_KEY)
-		set_error(service, CONNMAN_SERVICE_ERROR_UNKNOWN);
+		clear_error(service);
 
 	return 0;
 }
@@ -4415,7 +4416,7 @@ static DBusMessage *set_property(DBusConnection *conn,
 			 * have the same effect as user connecting the VPN =
 			 * clear previous error and change state to idle.
 			 */
-			set_error(service, CONNMAN_SERVICE_ERROR_UNKNOWN);
+			clear_error(service);
 
 			if (service->state == CONNMAN_SERVICE_STATE_FAILURE) {
 				service->state = CONNMAN_SERVICE_STATE_IDLE;
@@ -4715,6 +4716,11 @@ static void set_error(struct connman_service *service,
 				DBUS_TYPE_STRING, &str);
 }
 
+static void clear_error(struct connman_service *service)
+{
+	set_error(service, CONNMAN_SERVICE_ERROR_UNKNOWN);
+}
+
 static void remove_timeout(struct connman_service *service)
 {
 	if (service->timeout > 0) {
@@ -4756,7 +4762,7 @@ static DBusMessage *clear_property(DBusConnection *conn,
 							DBUS_TYPE_INVALID);
 
 	if (g_str_equal(name, "Error")) {
-		set_error(service, CONNMAN_SERVICE_ERROR_UNKNOWN);
+		clear_error(service);
 
 		__connman_service_clear_error(service);
 		service_complete(service);
@@ -6836,7 +6842,7 @@ static void request_input_cb(struct connman_service *service,
 
 	if (err >= 0) {
 		/* We forget any previous error. */
-		set_error(service, CONNMAN_SERVICE_ERROR_UNKNOWN);
+		clear_error(service);
 
 		__connman_service_connect(service,
 					CONNMAN_SERVICE_CONNECT_REASON_USER);
@@ -7058,7 +7064,7 @@ static int service_indicate_state(struct connman_service *service)
 		break;
 
 	case CONNMAN_SERVICE_STATE_READY:
-		set_error(service, CONNMAN_SERVICE_ERROR_UNKNOWN);
+		clear_error(service);
 
 		if (service->new_service &&
 				__connman_stats_service_register(service) == 0) {
@@ -7125,7 +7131,7 @@ static int service_indicate_state(struct connman_service *service)
 		break;
 
 	case CONNMAN_SERVICE_STATE_DISCONNECT:
-		set_error(service, CONNMAN_SERVICE_ERROR_UNKNOWN);
+		clear_error(service);
 
 		reply_pending(service, ECONNABORTED);
 


### PR DESCRIPTION
There are a suffient number of instantiations of the following implementation pattern:

```
        set_error(service, CONNMAN_SERVICE_ERROR_UNKNOWN);
```
    
to clear or reset the "Error" service property where it makes sense to embody this in a single function.
    
This introduces and leverages the `clear_error` function to embody this pattern.