### PR TITLE
ipconfig: Return a unique string for 'CONNMAN_IPCONFIG_TYPE_ALL'.

### DIFF
--- a/src/ipconfig.c
+++ b/src/ipconfig.c
@@ -225,12 +225,13 @@ const char *__connman_ipconfig_type2string(enum connman_ipconfig_type type)
 {
 	switch (type) {
 	case CONNMAN_IPCONFIG_TYPE_UNKNOWN:
-	case CONNMAN_IPCONFIG_TYPE_ALL:
 		return "unknown";
 	case CONNMAN_IPCONFIG_TYPE_IPV4:
 		return "IPv4";
 	case CONNMAN_IPCONFIG_TYPE_IPV6:
 		return "IPv6";
+	case CONNMAN_IPCONFIG_TYPE_ALL:
+		return "IPv4 + IPv6";
 	}
 
 	return NULL;


### PR DESCRIPTION
At commit 89f70d225df6 ("_ipconfig: Define unique value for CONNMAN_IPCONFIG_TYPE_ALL_"), a unique enumertion value was provided for `CONNMAN_IPCONFIG_TYPE_ALL` to make it semantically different from `CONNMAN_IPCONFIG_TYPE_ALL`; however, a unique string returned from `__connman_ipconfig_type2string` was not, leaving it to misleadingly return "_unknown_" for `CONNMAN_IPCONFIG_TYPE_ALL`.

This addresses this oversight by returning a unique string for `CONNMAN_IPCONFIG_TYPE_ALL`, "_IPv4 + IPv6_".