### PR TITLE
ipconfig: Const-qualify 'ipconfig' parameters.

### DIFF
--- a/src/connman.h
+++ b/src/connman.h
@@ -378,7 +378,7 @@ const char *__connman_ipconfig_get_peer(struct connman_ipconfig *ipconfig);
 void __connman_ipconfig_set_peer(struct connman_ipconfig *ipconfig, const char *address);
 const char *__connman_ipconfig_get_broadcast(struct connman_ipconfig *ipconfig);
 void __connman_ipconfig_set_broadcast(struct connman_ipconfig *ipconfig, const char *broadcast);
-const char *__connman_ipconfig_get_gateway(struct connman_ipconfig *ipconfig);
+const char *__connman_ipconfig_get_gateway(const struct connman_ipconfig *ipconfig);
 void __connman_ipconfig_set_gateway(struct connman_ipconfig *ipconfig, const char *gateway);
 unsigned char __connman_ipconfig_get_prefixlen(struct connman_ipconfig *ipconfig);
 void __connman_ipconfig_set_prefixlen(struct connman_ipconfig *ipconfig, unsigned char prefixlen);
@@ -410,8 +410,8 @@ enum connman_ipconfig_method __connman_ipconfig_get_method(
 int __connman_ipconfig_address_add(struct connman_ipconfig *ipconfig);
 int __connman_ipconfig_address_remove(struct connman_ipconfig *ipconfig);
 int __connman_ipconfig_address_unset(struct connman_ipconfig *ipconfig);
-int __connman_ipconfig_gateway_add(struct connman_ipconfig *ipconfig);
-void __connman_ipconfig_gateway_remove(struct connman_ipconfig *ipconfig);
+int __connman_ipconfig_gateway_add(const struct connman_ipconfig *ipconfig);
+void __connman_ipconfig_gateway_remove(const struct connman_ipconfig *ipconfig);
 
 int __connman_ipconfig_set_proxy_autoconfig(struct connman_ipconfig *ipconfig,
 							const char *url);

--- a/src/ipconfig.c
+++ b/src/ipconfig.c
@@ -1303,7 +1303,7 @@ void __connman_ipconfig_set_broadcast(struct connman_ipconfig *ipconfig,
 	ipconfig->address->broadcast = g_strdup(broadcast);
 }
 
-const char *__connman_ipconfig_get_gateway(struct connman_ipconfig *ipconfig)
+const char *__connman_ipconfig_get_gateway(const struct connman_ipconfig *ipconfig)
 {
 	if (!ipconfig->address)
 		return NULL;
@@ -1322,7 +1322,7 @@ void __connman_ipconfig_set_gateway(struct connman_ipconfig *ipconfig,
 	ipconfig->address->gateway = g_strdup(gateway);
 }
 
-int __connman_ipconfig_gateway_add(struct connman_ipconfig *ipconfig)
+int __connman_ipconfig_gateway_add(const struct connman_ipconfig *ipconfig)
 {
 	struct connman_service *service;
 
@@ -1348,7 +1348,7 @@ int __connman_ipconfig_gateway_add(struct connman_ipconfig *ipconfig)
 	return 0;
 }
 
-void __connman_ipconfig_gateway_remove(struct connman_ipconfig *ipconfig)
+void __connman_ipconfig_gateway_remove(const struct connman_ipconfig *ipconfig)
 {
 	struct connman_service *service;
 


### PR DESCRIPTION
Const-qualify the ipconfig arguments of `__connman_ipconfig_get_gateway` and `__connman_ipconfig_gateway_{add,remove}` to make it clear to the compiler, static analyzers, and human readers that the functions have no `ipconfig` mutation side effects.