### PR TITLE
ipconfig: Add DBG and Documentation to '__connman_ipconfig_gateway_{add,remove}'

### DIFF
--- a/src/ipconfig.c
+++ b/src/ipconfig.c
@@ -103,6 +103,11 @@ static GHashTable *ipdevice_hash = NULL;
 static GList *ipconfig_list = NULL;
 static bool is_ipv6_supported = false;
 
+static const char *maybe_null(const void *pointer)
+{
+	return pointer ? pointer : "<null>";
+}
+
 static void store_set_str(struct ipconfig_store *store,
 			const char *key, const char *val)
 
@@ -1325,8 +1330,13 @@ void __connman_ipconfig_set_gateway(struct connman_ipconfig *ipconfig,
 int __connman_ipconfig_gateway_add(const struct connman_ipconfig *ipconfig)
 {
 	struct connman_service *service;
+	g_autofree char *interface = NULL;
 
-	DBG("");
+	interface = connman_inet_ifname(ipconfig->index);
+
+	DBG("ipconfig %p type %d (%s) index %d (%s)", ipconfig,
+		ipconfig->type, __connman_ipconfig_type2string(ipconfig->type),
+		ipconfig->index, maybe_null(interface));
 
 	if (!ipconfig->address)
 		return -EINVAL;
@@ -1335,7 +1345,7 @@ int __connman_ipconfig_gateway_add(const struct connman_ipconfig *ipconfig)
 	if (!service)
 		return -EINVAL;
 
-	DBG("type %d gw %s peer %s", ipconfig->type,
+	DBG("gw %s peer %s",
 		ipconfig->address->gateway, ipconfig->address->peer);
 
 	if (ipconfig->type == CONNMAN_IPCONFIG_TYPE_IPV6 ||
@@ -1351,8 +1361,13 @@ int __connman_ipconfig_gateway_add(const struct connman_ipconfig *ipconfig)
 void __connman_ipconfig_gateway_remove(const struct connman_ipconfig *ipconfig)
 {
 	struct connman_service *service;
+	g_autofree char *interface = NULL;
 
-	DBG("");
+	interface = connman_inet_ifname(ipconfig->index);
+
+	DBG("ipconfig %p type %d (%s) index %d (%s)", ipconfig,
+		ipconfig->type, __connman_ipconfig_type2string(ipconfig->type),
+		ipconfig->index, maybe_null(interface));
 
 	service = __connman_service_lookup_from_index(ipconfig->index);
 	if (service)

--- a/src/ipconfig.c
+++ b/src/ipconfig.c
@@ -1327,6 +1327,31 @@ void __connman_ipconfig_set_gateway(struct connman_ipconfig *ipconfig,
 	ipconfig->address->gateway = g_strdup(gateway);
 }
 
+/**
+ *  @brief
+ *    Add, or set, the gateway, or default router, for a network
+ *    service.
+ *
+ *  This attempts to add, or set, the gateway, or default router, for
+ *  a network service using the specified IP configuration.
+ *
+ *  @param[in]  ipconfig  A pointer to the immutable IP configuration
+ *                        containing the network interface index @a
+ *                        index as the lookup key for the network
+ *                        service for which to add, or set, the
+ *                        gateway.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If the @a address field of @a ipconfig is null,
+ *                    if a cooresponding service cannot be found for
+ *                    the network interface index @a index of @a
+ *                    ipconfig, or if the network interface index
+ *                    associated with @a service is invalid.
+ *
+ *  @sa __connman_ipconfig_gateway_remove
+ *  @sa __connman_connection_gateway_add
+ *
+ */
 int __connman_ipconfig_gateway_add(const struct connman_ipconfig *ipconfig)
 {
 	struct connman_service *service;
@@ -1358,6 +1383,24 @@ int __connman_ipconfig_gateway_add(const struct connman_ipconfig *ipconfig)
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Remove, or clear, the gateway, or default router, for a network
+ *    service.
+ *
+ *  This attempts to remove, or clear, the gateway, or default router, for
+ *  a network service using the specified IP configuration.
+ *
+ *  @param[in]  ipconfig  A pointer to the immutable IP configuration
+ *                        containing the network interface index @a
+ *                        index as the lookup key for the network
+ *                        service for which to remove, or clear, the
+ *                        gateway.
+ *
+ *  @sa __connman_ipconfig_gateway_add
+ *  @sa __connman_connection_gateway_remove
+ *
+ */
 void __connman_ipconfig_gateway_remove(const struct connman_ipconfig *ipconfig)
 {
 	struct connman_service *service;


### PR DESCRIPTION
This not only expands and harmonizes the initial `DBG` statements in `__connman_ipconfig_gateway_{add,remove}` to aid debugging in a multi-technology environment with "EnableOnlineToReadyTransition" but also adds function documentation to these functions.