### PR TITLE
network: Const-qualify network leaf getter functions.

### DIFF
--- a/include/network.h
+++ b/include/network.h
@@ -81,8 +81,8 @@ connman_network_ref_debug(struct connman_network *network,
 void connman_network_unref_debug(struct connman_network *network,
 			const char *file, int line, const char *caller);
 
-enum connman_network_type connman_network_get_type(struct connman_network *network);
-const char *connman_network_get_identifier(struct connman_network *network);
+enum connman_network_type connman_network_get_type(const struct connman_network *network);
+const char *connman_network_get_identifier(const struct connman_network *network);
 
 void connman_network_set_index(struct connman_network *network, int index);
 int connman_network_get_index(const struct connman_network *network);

--- a/src/connman.h
+++ b/src/connman.h
@@ -623,7 +623,7 @@ int __connman_network_clear_ipconfig(struct connman_network *network,
 int __connman_network_enable_ipconfig(struct connman_network *network,
 				struct connman_ipconfig *ipconfig);
 
-const char *__connman_network_get_type(struct connman_network *network);
+const char *__connman_network_get_type(const struct connman_network *network);
 const char *__connman_network_get_group(struct connman_network *network);
 const char *__connman_network_get_ident(struct connman_network *network);
 bool __connman_network_get_weakness(struct connman_network *network);

--- a/src/network.c
+++ b/src/network.c
@@ -1333,7 +1333,7 @@ void connman_network_unref_debug(struct connman_network *network,
 	network_destruct(network);
 }
 
-const char *__connman_network_get_type(struct connman_network *network)
+const char *__connman_network_get_type(const struct connman_network *network)
 {
 	return type2string(network->type);
 }
@@ -1345,7 +1345,7 @@ const char *__connman_network_get_type(struct connman_network *network)
  * Get type of network
  */
 enum connman_network_type connman_network_get_type(
-				struct connman_network *network)
+				const struct connman_network *network)
 {
 	return network->type;
 }
@@ -1356,7 +1356,7 @@ enum connman_network_type connman_network_get_type(
  *
  * Get identifier of network
  */
-const char *connman_network_get_identifier(struct connman_network *network)
+const char *connman_network_get_identifier(const struct connman_network *network)
 {
 	return network->identifier;
 }


### PR DESCRIPTION
Const-qualify the network arguments in network leaf getter and introspection functions to make it clear to the compiler, static analyzers, and human readers that the function is strictly a getter or introspection function with no network mutation side effects.