### PR TITLE
service: Const-qualify 'service' param in '__connman_service_nameserver_{add,del}_routes'.

### DIFF
--- a/src/connman.h
+++ b/src/connman.h
@@ -779,9 +779,9 @@ int __connman_service_nameserver_append(struct connman_service *service,
 int __connman_service_nameserver_remove(struct connman_service *service,
 				const char *nameserver, bool is_auto);
 void __connman_service_nameserver_clear(struct connman_service *service);
-void __connman_service_nameserver_add_routes(struct connman_service *service,
+void __connman_service_nameserver_add_routes(const struct connman_service *service,
 						const char *gw);
-void __connman_service_nameserver_del_routes(struct connman_service *service,
+void __connman_service_nameserver_del_routes(const struct connman_service *service,
 					enum connman_ipconfig_type type);
 void __connman_service_set_timeservers(struct connman_service *service,
 						char **timeservers);

--- a/src/service.c
+++ b/src/service.c
@@ -1410,7 +1410,7 @@ static void nameserver_del_routes(int index, char **nameservers,
 	}
 }
 
-void __connman_service_nameserver_add_routes(struct connman_service *service,
+void __connman_service_nameserver_add_routes(const struct connman_service *service,
 						const char *gw)
 {
 	int index;
@@ -1438,7 +1438,7 @@ void __connman_service_nameserver_add_routes(struct connman_service *service,
 	}
 }
 
-void __connman_service_nameserver_del_routes(struct connman_service *service,
+void __connman_service_nameserver_del_routes(const struct connman_service *service,
 					enum connman_ipconfig_type type)
 {
 	int index;


### PR DESCRIPTION
Const-qualify the network service arguments of `__connman_service_nameserver_{add,del}_routes` to make it clear to the compiler, static analyzers, and human readers that the functions have no network service mutation side effects.