### PR TITLE
connection: Improve Connection Gateway Debugging and Documentation

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -49,6 +49,10 @@ void connman_debug(const char *format, ...)
 	}						\
 } while (0)
 
+/**
+ *  Debug-level logging descriptor that may be used to control debug
+ *  output on a per-file or -symbol basis.
+ */
 struct connman_debug_desc {
 	const char *name;
 	const char *file;
@@ -58,18 +62,88 @@ struct connman_debug_desc {
 	unsigned int flags;
 } __attribute__((aligned(8)));
 
+/**
+ *  @def CONNMAN_DEBUG_DESC_INSTANTIATE(symbol, _name, _file, _flags)
+ *
+ *  @brief
+ *    Convenience preprocessor macro for declaring and instantiating an
+ *    instance of #connmand_debug_desc.
+ *
+ *  @param[in]  symbol   The name of the #connman_debug_desc instance
+ *                       to instantiate.
+ *  @param[in]  _name    An optional pointer to an immutable null-
+ *                       terminated C string containing the name of
+ *                       the #connman_debug_desc- controlled symbol.
+ *  @param[in]  _file    A pointer to an immutable null-terminated C
+ *                       string containing the name of the
+ *                       #connman_debug_desc-controlled source file.
+ *  @param[in]  _flags   Flags that control the interpretation and
+ *                       behavior of the instantiated
+ *                       #connman_debug_desc instance.
+ *
+ */
 #define CONNMAN_DEBUG_DESC_INSTANTIATE(symbol, _name, _file, _flags) \
 	static struct connman_debug_desc symbol \
 	__attribute__((used, section("__debug"), aligned(8))) = { \
 		.name = _name, .file = _file, .flags = _flags \
 	}
 
+/**
+ *  @def CONNMAN_DEBUG_ALIAS(suffix)
+ *
+ *  @brief
+ *    Convenience preprocessor macro for declaring and instantiating
+ *    an alias (see #CONNMAN_DEBUG_FLAG_ALIAS) instance of
+ *    #connmand_debug_desc.
+ *
+ *  @param[in]  suffix  The suffix to concatenate to the name of the
+ *                      #connman_debug_desc alias instance to
+ *                      instantiate.
+ *
+ */
 #define CONNMAN_DEBUG_ALIAS(suffix) \
 	CONNMAN_DEBUG_DESC_INSTANTIATE(__debug_alias_##suffix, \
 		#suffix, \
 		__FILE__, \
 		CONNMAN_DEBUG_FLAG_ALIAS)
 
+/**
+ *  @def CONNMAN_DEBUG(function, fmt, args...)
+ *
+ *  @brief
+ *    Convenience preprocessor macro for declaring and instantiating
+ *    an instance of #connmand_debug_desc for controlling an
+ *    invocation of #connman_debug with it that includes both the
+ *    file and function name the macro was invoked in or attributed
+ *    to.
+ *
+ *  This instantiates a scoped-instance of #connmand_debug_desc and
+ *  then, if that instance has its #CONNMAN_DEBUG_FLAG_PRINT flag
+ *  asserted, invokes a call to #connman_debug with the format:
+ *
+ *    "<file>:<function>() <fmt> ..."
+ *
+ *  where <file> is the preprocessor symbol __FILE__, <function> is
+ *  caller-specified, <fmt> is from @a fmt, and '...' is from @a
+ *  'args...'.
+ *
+ *  @param[in]  function  A pointer to an immutble null-terminated C
+ *                        string containing the name of the function
+ *                        in which the macro is being instantiated or
+ *                        to which the invocation of the macro should
+ *                        be attributed to. For example, __FUNCTION__.
+ *  @param[in]  fmt       A pointer to an immutable null-terminated C
+ *                        string container the log message, consisting
+ *                        of a printf-style format string composed of
+ *                        zero or more output conversion directives.
+ *  @param[in]  args...   A variadic argument list, where each
+ *                        argument corresponds with its peer output
+ *                        conversion directive in @a fmt.
+ *
+ *  @sa CONNMAN_DEBUG_DESC_INSTANTIATE
+ *  @sa connman_debug
+ *
+ */
 #define CONNMAN_DEBUG(function, fmt, args...) do { \
 	CONNMAN_DEBUG_DESC_INSTANTIATE(__connman_debug_desc, \
 		0, \
@@ -81,12 +155,35 @@ struct connman_debug_desc {
 	} while (0)
 
 /**
- * DBG:
- * @fmt: format string
- * @arg...: list of arguments
+ *  @def DBG(fmt, args...)
  *
- * Simple macro around connman_debug() which also include the function
- * name it is called in.
+ *  @brief
+ *    Convenience preprocessor macro for declaring an instance of
+ *    #connmand_debug_desc for controlling an invocation of
+ *    #connman_debug with it that includes both the file and function
+ *    name the macro was invoked in.
+ *
+ *  This instantiates a scoped-instance of #connmand_debug_desc and
+ *  then, if that instance has its #CONNMAN_DEBUG_FLAG_PRINT flag
+ *  asserted, invokes a call to #connman_debug with the format:
+ *
+ *    "<file>:<function>() <fmt> ..."
+ *
+ *  where <file> is the preprocessor symbol __FILE__, <function> is
+ *  the preprocessor symbol __func__, <fmt> is from @a fmt, and
+ *  '...' is from @a 'args...'.
+ *
+ *  @param[in]  fmt      A pointer to an immutable null-terminated C
+ *                       string container the log message, consisting
+ *                       of a printf-style format string composed of
+ *                       zero or more output conversion directives.
+ *  @param[in]  args...  A variadic argument list, where each
+ *                       argument corresponds with its peer output
+ *                       conversion directive in @a fmt.
+ *
+ *  @sa CONNMAN_DEBUG
+ *  @sa connman_debug
+ *
  */
 #define DBG(fmt, args...) CONNMAN_DEBUG(__func__, fmt, ##args)
 

--- a/include/log.h
+++ b/include/log.h
@@ -58,11 +58,27 @@ struct connman_debug_desc {
 	unsigned int flags;
 } __attribute__((aligned(8)));
 
-#define CONNMAN_DEBUG_DEFINE(name) \
-	static struct connman_debug_desc __debug_alias_ ## name \
+#define CONNMAN_DEBUG_DESC_INSTANTIATE(symbol, _name, _file, _flags) \
+	static struct connman_debug_desc symbol \
 	__attribute__((used, section("__debug"), aligned(8))) = { \
-		#name, __FILE__, CONNMAN_DEBUG_FLAG_ALIAS \
-	};
+		.name = _name, .file = _file, .flags = _flags \
+	}
+
+#define CONNMAN_DEBUG_ALIAS(suffix) \
+	CONNMAN_DEBUG_DESC_INSTANTIATE(__debug_alias_##suffix, \
+		#suffix, \
+		__FILE__, \
+		CONNMAN_DEBUG_FLAG_ALIAS)
+
+#define CONNMAN_DEBUG(function, fmt, args...) do { \
+	CONNMAN_DEBUG_DESC_INSTANTIATE(__connman_debug_desc, \
+		0, \
+		__FILE__, \
+		CONNMAN_DEBUG_FLAG_DEFAULT); \
+		if (__connman_debug_desc.flags & CONNMAN_DEBUG_FLAG_PRINT) \
+			connman_debug("%s:%s() " fmt, \
+					__FILE__, function, ##args); \
+	} while (0)
 
 /**
  * DBG:
@@ -72,15 +88,7 @@ struct connman_debug_desc {
  * Simple macro around connman_debug() which also include the function
  * name it is called in.
  */
-#define DBG(fmt, arg...) do { \
-	static struct connman_debug_desc __connman_debug_desc \
-	__attribute__((used, section("__debug"), aligned(8))) = { \
-		.file = __FILE__, .flags = CONNMAN_DEBUG_FLAG_DEFAULT, \
-	}; \
-	if (__connman_debug_desc.flags & CONNMAN_DEBUG_FLAG_PRINT) \
-		connman_debug("%s:%s() " fmt, \
-					__FILE__, __FUNCTION__ , ## arg); \
-} while (0)
+#define DBG(fmt, args...) CONNMAN_DEBUG(__func__, fmt, ##args)
 
 #ifdef __cplusplus
 }

--- a/src/connection.c
+++ b/src/connection.c
@@ -59,11 +59,45 @@ struct gateway_data {
 
 static GHashTable *gateway_hash = NULL;
 
+/**
+ *  @brief
+ *    Return the specified pointer if non-null; otherwise, the
+ *    immutable "<null>" string.
+ *
+ *  @param[in]  pointer  The pointer to be returned if non-null.
+ *
+ *  @returns
+ *     @a pointer if non-null; otherwise the "<null>" immutable
+ *     null-terminated C string.
+ *
+ */
 static const char *maybe_null(const void *pointer)
 {
 	return pointer ? pointer : "<null>";
 }
 
+/**
+ *  @brief
+ *    Conditionally log the specified gateway configuration.
+ *
+ *  This conditionally logs at the debug level the specified
+ *  #gateway_config gateway configuration, @a config, with the
+ *  provided description, @a description, attributed to the provided
+ *  function name, @a function.
+ *
+ *  @param[in]  function     A pointer to an immutable null-terminated
+ *                           C string containing the function name to
+ *                           which the call to this function should be
+ *                           attributed.
+ *  @param[in]  description  A pointer to an immutable null-terminated
+ *                           C string briefly describing @a
+ *                           config. For example, "ipv4_config".
+ *  @param[in]  config       A pointer to the immutable gateway
+ *                           configuration to conditionally log.
+ *
+ *  @sa CONNMAN_DEBUG
+ *
+ */
 static void gateway_config_debug(const char *function,
 				const char *description,
 				const struct gateway_config *config)
@@ -95,6 +129,29 @@ static void gateway_config_debug(const char *function,
 	}
 }
 
+/**
+ *  @brief
+ *    Conditionally log the specified gateway data.
+ *
+ *  This conditionally logs at the debug level the specified
+ *  #gateway_data gateway data, @a data, with the provided
+ *  description, @a description, attributed to the provided function
+ *  name, @a function.
+ *
+ *  @param[in]  function     A pointer to an immutable null-terminated
+ *                           C string containing the function name to
+ *                           which the call to this function should be
+ *                           attributed.
+ *  @param[in]  description  A pointer to an immutable null-terminated
+ *                           C string briefly describing @a
+ *                           data. For example, "default_gateway".
+ *  @param[in]  data         A pointer to the immutable gateway
+ *                           data to conditionally log.
+ *
+ *  @sa CONNMAN_DEBUG
+ *  @sa gateway_config_debug
+ *
+ */
 static void gateway_data_debug(const char *function,
 				const char *description,
 				const struct gateway_data *data)

--- a/src/connection.c
+++ b/src/connection.c
@@ -1320,6 +1320,24 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 	}
 }
 
+/**
+ *  @brief
+ *    Handle a potential change in gateways.
+ *
+ *  This may be invoked by other modules in the event of service and
+ *  technology changes to reexamine and, if necessary, update active
+ *  network interface gateways and their associated routing table
+ *  entries.
+ *
+ *  @returns
+ *    True if an active gateway was updated; otherwise, false.
+ *
+ *  @sa __connman_connection_gateway_add
+ *  @sa __connman_connection_gateway_remove
+ *  @sa set_default_gateway
+ *  @sa unset_default_gateway
+ *
+ */
 bool __connman_connection_update_gateway(void)
 {
 	struct gateway_data *default_gateway;
@@ -1329,6 +1347,10 @@ bool __connman_connection_update_gateway(void)
 
 	DBG("");
 
+	/*
+	 * If there is no service-to-gateway data hash, then there is
+	 * nothing to update and do; simply return.
+	 */
 	if (!gateway_hash)
 		return updated;
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -32,6 +32,12 @@
 
 #include "connman.h"
 
+#define GATEWAY_CONFIG_DBG(description, config) \
+	gateway_config_debug(__func__, description, config)
+
+#define GATEWAY_DATA_DBG(description, data) \
+	gateway_data_debug(__func__, description, data)
+
 struct gateway_config {
 	bool active;
 	char *gateway;
@@ -52,6 +58,79 @@ struct gateway_data {
 };
 
 static GHashTable *gateway_hash = NULL;
+
+static const char *maybe_null(const void *pointer)
+{
+	return pointer ? pointer : "<null>";
+}
+
+static void gateway_config_debug(const char *function,
+				const char *description,
+				const struct gateway_config *config)
+{
+	g_autofree char *vpn_phy_interface = NULL;
+
+	if (!function || !description)
+		return;
+
+	if (!config)
+		CONNMAN_DEBUG(function, "%s %p", description, config);
+	else {
+		if (config->vpn_phy_index >= 0)
+			vpn_phy_interface =
+				connman_inet_ifname(config->vpn_phy_index);
+
+		CONNMAN_DEBUG(function,
+			"%s %p: { active: %u, gateway: %p (%s), "
+			"vpn: %u, vpn_ip: %p (%s), vpn_phy_index: %d (%s), "
+			"vpn_phy_ip: %p (%s) }",
+			description,
+			config,
+			config->active,
+			config->gateway, maybe_null(config->gateway),
+			config->vpn,
+			config->vpn_ip, maybe_null(config->vpn_ip),
+			config->vpn_phy_index, maybe_null(vpn_phy_interface),
+			config->vpn_phy_ip, maybe_null(config->vpn_phy_ip));
+	}
+}
+
+static void gateway_data_debug(const char *function,
+				const char *description,
+				const struct gateway_data *data)
+{
+	g_autofree char *interface = NULL;
+
+	if (!function || !description)
+		return;
+
+	if (!data)
+		CONNMAN_DEBUG(function, "%s %p", description, data);
+	else {
+		interface = connman_inet_ifname(data->index);
+
+		CONNMAN_DEBUG(function,
+			"%s %p: { index: %d (%s), service: %p (%s), "
+			"ipv4_gateway: %p, ipv6_gateway: %p, default_checked: %u }",
+			description,
+			data,
+			data->index,
+			maybe_null(interface),
+			data->service,
+			connman_service_get_identifier(data->service),
+			data->ipv4_gateway,
+			data->ipv6_gateway,
+			data->default_checked);
+
+		if (data->ipv4_gateway)
+			gateway_config_debug(function, "ipv4_gateway",
+				data->ipv4_gateway);
+
+		if (data->ipv6_gateway)
+			gateway_config_debug(function, "ipv6_gateway",
+				data->ipv6_gateway);
+	}
+}
 
 static struct gateway_config *find_gateway(int index, const char *gateway)
 {
@@ -282,6 +361,8 @@ static int del_routes(struct gateway_data *data,
 	int status4 = 0, status6 = 0;
 	bool do_ipv4 = false, do_ipv6 = false;
 
+	GATEWAY_DATA_DBG("data", data);
+
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
 		do_ipv4 = true;
 	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
@@ -333,6 +414,8 @@ static int disable_gateway(struct gateway_data *data,
 			enum connman_ipconfig_type type)
 {
 	bool active = false;
+
+	GATEWAY_DATA_DBG("data", data);
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4) {
 		if (data->ipv4_gateway)
@@ -426,6 +509,8 @@ static void set_default_gateway(struct gateway_data *data,
 	int status4 = 0, status6 = 0;
 	bool do_ipv4 = false, do_ipv6 = false;
 
+	GATEWAY_DATA_DBG("data", data);
+
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
 		do_ipv4 = true;
 	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
@@ -507,6 +592,8 @@ static void unset_default_gateway(struct gateway_data *data,
 	int index;
 	bool do_ipv4 = false, do_ipv6 = false;
 
+	GATEWAY_DATA_DBG("data", data);
+
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
 		do_ipv4 = true;
 	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
@@ -586,6 +673,9 @@ static bool choose_default_gateway(struct gateway_data *data,
 {
 	bool downgraded = false;
 
+	GATEWAY_DATA_DBG("data", data);
+	GATEWAY_DATA_DBG("candidate", candidate);
+
 	/*
 	 * If the current default is not active, then we mark
 	 * this one as default. If the other one is already active
@@ -641,6 +731,8 @@ static void connection_newgateway(int index, const char *gateway)
 	if (!config)
 		return;
 
+	GATEWAY_CONFIG_DBG("config", config);
+
 	config->active = true;
 
 	/*
@@ -651,6 +743,8 @@ static void connection_newgateway(int index, const char *gateway)
 	data = lookup_gateway_data(config);
 	if (!data)
 		return;
+
+	GATEWAY_DATA_DBG("data", data);
 
 	if (data->default_checked)
 		return;
@@ -690,6 +784,8 @@ static void remove_gateway(gpointer user_data)
 
 	DBG("gateway ipv4 %p ipv6 %p", data->ipv4_gateway, data->ipv6_gateway);
 
+	GATEWAY_DATA_DBG("data", data);
+
 	if (data->ipv4_gateway) {
 		g_free(data->ipv4_gateway->gateway);
 		g_free(data->ipv4_gateway->vpn_ip);
@@ -717,12 +813,18 @@ static void connection_delgateway(int index, const char *gateway)
 	DBG("index %d gateway %s", index, gateway);
 
 	config = find_gateway(index, gateway);
-	if (config)
+	if (config) {
+		GATEWAY_CONFIG_DBG("config", config);
+
 		config->active = false;
+	}
 
 	data = find_default_gateway();
-	if (data)
+	if (data) {
+		GATEWAY_DATA_DBG("data", data);
+
 		set_default_gateway(data, CONNMAN_IPCONFIG_TYPE_ALL);
+	}
 }
 
 static struct connman_rtnl connection_rtnl = {
@@ -836,10 +938,14 @@ int __connman_connection_gateway_add(struct connman_service *service,
 	if (!new_gateway)
 		return -EINVAL;
 
+	GATEWAY_DATA_DBG("new_gateway", new_gateway);
+
 	active_gateway = find_active_gateway();
 
 	DBG("active %p index %d new %p", active_gateway,
 		active_gateway ? active_gateway->index : -1, new_gateway);
+
+	GATEWAY_DATA_DBG("active_gateway", active_gateway);
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4 &&
 				new_gateway->ipv4_gateway) {
@@ -931,6 +1037,8 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 	if (!data)
 		return;
 
+	GATEWAY_DATA_DBG("service_data", data);
+
 	if (do_ipv4 && data->ipv4_gateway)
 		set_default4 = data->ipv4_gateway->vpn;
 
@@ -977,6 +1085,9 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 	 */
 	if (set_default4 || set_default6 || err < 0) {
 		data = find_default_gateway();
+
+		GATEWAY_DATA_DBG("default_data", data);
+
 		if (data)
 			set_default_gateway(data, type);
 	}
@@ -996,6 +1107,8 @@ bool __connman_connection_update_gateway(void)
 
 	DBG("default %p", default_gateway);
 
+	GATEWAY_DATA_DBG("default_gateway", default_gateway);
+
 	/*
 	 * There can be multiple active gateways so we need to
 	 * check them all.
@@ -1004,6 +1117,8 @@ bool __connman_connection_update_gateway(void)
 
 	while (g_hash_table_iter_next(&iter, &key, &value)) {
 		struct gateway_data *active_gateway = value;
+
+		GATEWAY_DATA_DBG("active_gateway", active_gateway);
 
 		if (active_gateway == default_gateway)
 			continue;

--- a/src/log.c
+++ b/src/log.c
@@ -38,7 +38,7 @@ static const char *program_exec;
 static const char *program_path;
 
 /* This makes sure we always have a __debug section. */
-CONNMAN_DEBUG_DEFINE(dummy);
+CONNMAN_DEBUG_ALIAS(dummy);
 
 /**
  * connman_info:


### PR DESCRIPTION
This improves connection gateway debugging with the following changes:

* This introduces and leverages two functions `gateway_{config,data}_debug` to conditionally log gateway data and configuration at the debug level.
* Expands, exhances, and refactors `DBG` statements throughout the module to improve symmetry in content, aid in debugging, and to reflect the newly-leveraged `GATEWAY_CONFIG_DBG` and `GATEWAY_DATA_DBG` macro which, in turn, are wrappers around `gateway_{config,data}_debug`.

In addition, this adds to or expands on function- and body-level documentation for:

* `connection_{add,del}gateway`
* `__connman_connection_gateway_{add,remove}`
* `__connman_connection_update_gateway`

The aforementioned `GATEWAY_CONFIG_DBG` and `GATEWAY_DATA_DBG` are supported by log module changes, including:

* Introduces `CONNMAN_DEBUG_DESC_INSTANTIATE` which declares and instantiates an instance of `connmand_debug_desc`.
* Replaces `CONNMAN_DEBUG_DEFINE` with `CONNMAN_DEBUG_ALIAS` which declares and instantiates an alias (that is, asserts the `CONNMAN_DEBUG_FLAG_ALIAS` flag) instance of `connmand_debug_desc`, using `CONNMAN_DEBUG_DESC_INSTANTIATE`.
* Introduces `CONNMAN_DEBUG` which declares and instantiates an instance of `connmand_debug_desc`, again using
`CONNMAN_DEBUG_DESC_INSTANTIATE`, for controlling an invocation of `connman_debug` with it that includes both the file and function name the macro was invoked in or attributed to.
    * The key difference between this and `DBG` is that this allows the caller to specify the function string rather than relying on `__FUNCTION__`.
* Redefines `DBG` against `CONNMAN_DEBUG` with `__func__` as the function parameter.
