### PR TITLE
connection: Introduce and Leverage IPv[46] Any / Unspecified Address String Constants and Functions

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -192,11 +192,51 @@ static void gateway_data_debug(const char *function,
 	}
 }
 
+/**
+ *  @brief
+ *    Determine whether the specified text-formatted IPv4 address is
+ *    the "any" or "unspecified" address.
+ *
+ *  This determines whether the specified text-formatted IPv4 address
+ *  is the "any" or "unspecified" address, that is "0.0.0.0".
+ *
+ *  @param[in]  address  A pointer to an immutable null-terminated C
+ *                       string containing the text-formatted address
+ *                       to determine whether it is the IPv4 "any" or
+ *                       "unspecified address.
+ *
+ *  @returns
+ *    True if @a address is the "any" or "unspecified" IPv4 address;
+ *    otherwise, false.
+ *
+ *  @sa is_ipv6_addr_any_str
+ *
+ */
 static bool is_ipv4_addr_any_str(const char *address)
 {
 	return g_strcmp0(ipv4_addr_any_str, address) == 0;
 }
 
+/**
+ *  @brief
+ *    Determine whether the specified text-formatted IPv6 address is
+ *    the "any" or "unspecified" address.
+ *
+ *  This determines whether the specified text-formatted IPv6 address
+ *  is the "any" or "unspecified" address, that is "::".
+ *
+ *  @param[in]  address  A pointer to an immutable null-terminated C
+ *                       string containing the text-formatted address
+ *                       to determine whether it is the IPv6 "any" or
+ *                       "unspecified address.
+ *
+ *  @returns
+ *    True if @a address is the "any" or "unspecified" IPv6 address;
+ *    otherwise, false.
+ *
+ *  @sa is_ipv4_addr_any_str
+ *
+ */
 static bool is_ipv6_addr_any_str(const char *address)
 {
 	return g_strcmp0(ipv6_addr_any_str, address) == 0;

--- a/src/connection.c
+++ b/src/connection.c
@@ -192,6 +192,16 @@ static void gateway_data_debug(const char *function,
 	}
 }
 
+static bool is_ipv4_addr_any_str(const char *address)
+{
+	return g_strcmp0(ipv4_addr_any_str, address) == 0;
+}
+
+static bool is_ipv6_addr_any_str(const char *address)
+{
+	return g_strcmp0(ipv6_addr_any_str, address) == 0;
+}
+
 /**
  *  @brief
  *    Find the gateway, or default router, configuration associated
@@ -488,8 +498,7 @@ static void set_vpn_routes(struct gateway_data *new_gateway,
 
 		DBG("active gw %s", active_gateway->ipv4_config->gateway);
 
-		if (g_strcmp0(active_gateway->ipv4_config->gateway,
-							ipv4_addr_any_str) != 0)
+		if (!is_ipv4_addr_any_str(active_gateway->ipv4_config->gateway))
 			dest = active_gateway->ipv4_config->gateway;
 		else
 			dest = NULL;
@@ -508,8 +517,7 @@ static void set_vpn_routes(struct gateway_data *new_gateway,
 
 		DBG("active gw %s", active_gateway->ipv6_config->gateway);
 
-		if (g_strcmp0(active_gateway->ipv6_config->gateway,
-					ipv6_addr_any_str) != 0)
+		if (!is_ipv6_addr_any_str(active_gateway->ipv6_config->gateway))
 			dest = active_gateway->ipv6_config->gateway;
 		else
 			dest = NULL;
@@ -540,8 +548,7 @@ static int del_routes(struct gateway_data *data,
 						data->index,
 						data->ipv4_config->vpn_ip);
 
-		} else if (g_strcmp0(data->ipv4_config->gateway,
-						ipv4_addr_any_str) == 0) {
+		} else if (is_ipv4_addr_any_str(data->ipv4_config->gateway)) {
 			status4 = connman_inet_clear_gateway_interface(
 								data->index);
 		} else {
@@ -559,8 +566,7 @@ static int del_routes(struct gateway_data *data,
 						data->index,
 						data->ipv6_config->vpn_ip);
 
-		} else if (g_strcmp0(data->ipv6_config->gateway,
-						ipv6_addr_any_str) == 0) {
+		} else if (is_ipv6_addr_any_str(data->ipv6_config->gateway)) {
 			status6 = connman_inet_clear_ipv6_gateway_interface(
 								data->index);
 		} else {
@@ -719,8 +725,7 @@ static void set_default_gateway(struct gateway_data *data,
 	index = __connman_service_get_index(data->service);
 
 	if (do_ipv4 && data->ipv4_config &&
-			g_strcmp0(data->ipv4_config->gateway,
-					ipv4_addr_any_str) == 0) {
+			is_ipv4_addr_any_str(data->ipv4_config->gateway)) {
 		if (connman_inet_set_gateway_interface(index) < 0)
 			return;
 		data->ipv4_config->active = true;
@@ -728,8 +733,7 @@ static void set_default_gateway(struct gateway_data *data,
 	}
 
 	if (do_ipv6 && data->ipv6_config &&
-			g_strcmp0(data->ipv6_config->gateway,
-					ipv6_addr_any_str) == 0) {
+			is_ipv6_addr_any_str(data->ipv6_config->gateway)) {
 		if (connman_inet_set_ipv6_gateway_interface(index) < 0)
 			return;
 		data->ipv6_config->active = true;
@@ -801,16 +805,14 @@ static void unset_default_gateway(struct gateway_data *data,
 	index = __connman_service_get_index(data->service);
 
 	if (do_ipv4 && data->ipv4_config &&
-			g_strcmp0(data->ipv4_config->gateway,
-					ipv4_addr_any_str) == 0) {
+			is_ipv4_addr_any_str(data->ipv4_config->gateway)) {
 		connman_inet_clear_gateway_interface(index);
 		data->ipv4_config->active = false;
 		return;
 	}
 
 	if (do_ipv6 && data->ipv6_config &&
-			g_strcmp0(data->ipv6_config->gateway,
-					ipv6_addr_any_str) == 0) {
+			is_ipv6_addr_any_str(data->ipv6_config->gateway)) {
 		connman_inet_clear_ipv6_gateway_interface(index);
 		data->ipv6_config->active = false;
 		return;
@@ -1070,7 +1072,7 @@ static void add_host_route(int family, int index, const char *gateway,
 {
 	switch (family) {
 	case AF_INET:
-		if (g_strcmp0(gateway, ipv4_addr_any_str) != 0) {
+		if (!is_ipv4_addr_any_str(gateway)) {
 			/*
 			 * We must not set route to the phy dev gateway in
 			 * VPN link. The packets to VPN link might be routed
@@ -1095,7 +1097,7 @@ static void add_host_route(int family, int index, const char *gateway,
 		break;
 
 	case AF_INET6:
-		if (g_strcmp0(gateway, ipv6_addr_any_str) != 0) {
+		if (!is_ipv6_addr_any_str(gateway)) {
 			if (service_type != CONNMAN_SERVICE_TYPE_VPN)
 				connman_inet_add_ipv6_host_route(index,
 								gateway, NULL);

--- a/src/connection.c
+++ b/src/connection.c
@@ -57,6 +57,9 @@ struct gateway_data {
 	bool default_checked;
 };
 
+static const char *const ipv4_addr_any_str = "0.0.0.0";
+static const char *const ipv6_addr_any_str = "::";
+
 static GHashTable *gateway_hash = NULL;
 
 /**
@@ -486,7 +489,7 @@ static void set_vpn_routes(struct gateway_data *new_gateway,
 		DBG("active gw %s", active_gateway->ipv4_config->gateway);
 
 		if (g_strcmp0(active_gateway->ipv4_config->gateway,
-							"0.0.0.0") != 0)
+							ipv4_addr_any_str) != 0)
 			dest = active_gateway->ipv4_config->gateway;
 		else
 			dest = NULL;
@@ -506,7 +509,7 @@ static void set_vpn_routes(struct gateway_data *new_gateway,
 		DBG("active gw %s", active_gateway->ipv6_config->gateway);
 
 		if (g_strcmp0(active_gateway->ipv6_config->gateway,
-								"::") != 0)
+					ipv6_addr_any_str) != 0)
 			dest = active_gateway->ipv6_config->gateway;
 		else
 			dest = NULL;
@@ -538,7 +541,7 @@ static int del_routes(struct gateway_data *data,
 						data->ipv4_config->vpn_ip);
 
 		} else if (g_strcmp0(data->ipv4_config->gateway,
-							"0.0.0.0") == 0) {
+						ipv4_addr_any_str) == 0) {
 			status4 = connman_inet_clear_gateway_interface(
 								data->index);
 		} else {
@@ -556,7 +559,8 @@ static int del_routes(struct gateway_data *data,
 						data->index,
 						data->ipv6_config->vpn_ip);
 
-		} else if (g_strcmp0(data->ipv6_config->gateway, "::") == 0) {
+		} else if (g_strcmp0(data->ipv6_config->gateway,
+						ipv6_addr_any_str) == 0) {
 			status6 = connman_inet_clear_ipv6_gateway_interface(
 								data->index);
 		} else {
@@ -716,7 +720,7 @@ static void set_default_gateway(struct gateway_data *data,
 
 	if (do_ipv4 && data->ipv4_config &&
 			g_strcmp0(data->ipv4_config->gateway,
-							"0.0.0.0") == 0) {
+					ipv4_addr_any_str) == 0) {
 		if (connman_inet_set_gateway_interface(index) < 0)
 			return;
 		data->ipv4_config->active = true;
@@ -725,7 +729,7 @@ static void set_default_gateway(struct gateway_data *data,
 
 	if (do_ipv6 && data->ipv6_config &&
 			g_strcmp0(data->ipv6_config->gateway,
-							"::") == 0) {
+					ipv6_addr_any_str) == 0) {
 		if (connman_inet_set_ipv6_gateway_interface(index) < 0)
 			return;
 		data->ipv6_config->active = true;
@@ -798,7 +802,7 @@ static void unset_default_gateway(struct gateway_data *data,
 
 	if (do_ipv4 && data->ipv4_config &&
 			g_strcmp0(data->ipv4_config->gateway,
-							"0.0.0.0") == 0) {
+					ipv4_addr_any_str) == 0) {
 		connman_inet_clear_gateway_interface(index);
 		data->ipv4_config->active = false;
 		return;
@@ -806,7 +810,7 @@ static void unset_default_gateway(struct gateway_data *data,
 
 	if (do_ipv6 && data->ipv6_config &&
 			g_strcmp0(data->ipv6_config->gateway,
-							"::") == 0) {
+					ipv6_addr_any_str) == 0) {
 		connman_inet_clear_ipv6_gateway_interface(index);
 		data->ipv6_config->active = false;
 		return;
@@ -1066,7 +1070,7 @@ static void add_host_route(int family, int index, const char *gateway,
 {
 	switch (family) {
 	case AF_INET:
-		if (g_strcmp0(gateway, "0.0.0.0") != 0) {
+		if (g_strcmp0(gateway, ipv4_addr_any_str) != 0) {
 			/*
 			 * We must not set route to the phy dev gateway in
 			 * VPN link. The packets to VPN link might be routed
@@ -1091,7 +1095,7 @@ static void add_host_route(int family, int index, const char *gateway,
 		break;
 
 	case AF_INET6:
-		if (g_strcmp0(gateway, "::") != 0) {
+		if (g_strcmp0(gateway, ipv6_addr_any_str) != 0) {
 			if (service_type != CONNMAN_SERVICE_TYPE_VPN)
 				connman_inet_add_ipv6_host_route(index,
 								gateway, NULL);
@@ -1176,10 +1180,10 @@ int __connman_connection_gateway_add(struct connman_service *service,
 	 * interface
 	 */
 	if (!gateway && type == CONNMAN_IPCONFIG_TYPE_IPV4)
-		gateway = "0.0.0.0";
+		gateway = ipv4_addr_any_str;
 
 	if (!gateway && type == CONNMAN_IPCONFIG_TYPE_IPV6)
-		gateway = "::";
+		gateway = ipv6_addr_any_str;
 
 	DBG("service %p index %d gateway %s vpn ip %s type %d",
 		service, index, gateway, peer, type);


### PR DESCRIPTION
The IPv4 and IPv6 any / unspecified address string literals, "0.0.0.0" and "::" respectively, and comparisons against them appear often enough throughout the code where they warrant referencing through file-scoped constants and introducing and leveraging introspection functions to encapsulate the comparison patterns.

This introduces and uses such constants and `is_ipv[46]_addr_any_str` introspection functions to encapsulate these comparison patterns.

