### PR TITLE
Connection: Refactor 'add_gateway'

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -645,6 +645,59 @@ static int disable_gateway(struct gateway_data *data,
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Associate, or add, a new gateway, or default router, with a
+ *    network service.
+ *
+ *  This attempts to associate, or add, a new gateway, or default
+ *  router, with a network service. On success, a strong (that is,
+ *  uses #connman_service_{ref,unref}) reference to @a service is
+ *  retained in the service-to-gateway data hash.
+ *
+ *  @note
+ *    The caller is responsible for deallocating the memory assigned
+ *    to @a *data on success.
+ *
+ *  @param[in,out]  service  A pointer to the mutable network service
+ *                           object with which to associate @a
+ *                           gateway. On success, a strong (that is,
+ *                           uses #connman_service_{ref,unref})
+ *                           reference to this service is retained
+ *                           in the service-to-gateway data hash.
+ *  @param[in]      index    The network interface index for the
+ *                           network interface backing @a service.
+ *  @param[in]      gateway  A pointer to an immutable null-
+ *                           terminated C string containing the
+ *                           text-formatted address of the gateway, or
+ *                           default router, with which to associated
+ *                           with @a service.
+ *  @param[in]      type     The IP configuration type for the gateway,
+ *                           or default router.
+ *  @param[in,out]  data     A pointer to mutable storage for a mutable
+ *                           pointer to a #gateway_data structure. On
+ *                           success, this is assigned a newly-
+ *                           allocated and added structure that
+ *                           associates the @a gateway with @a service
+ *                           and @a type. The caller is responsible
+ *                           for deallocating the memory assigned to
+ *                           @a *data on success.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If service is null, if the network interface @a
+ *                    index is invalid, if @a gateway is null or zero
+ *                    in length, if type is not
+ *                    #CONNMAN_IPCONFIG_TYPE_IPV4 or
+ *                    #CONNMAN_IPCONFIG_TYPE_IPV6, or if @a data is
+ *                    null.
+ *  @retval  -ENOMEM  If memory could not be allocated for the
+ *                    #gateway_data structure and its associated
+ *                    #gateway_config.
+ *
+ *  @sa __connman_connection_gateway_add
+ *  @sa disable_gateway
+ *
+ */
 static int add_gateway(struct connman_service *service,
 					int index, const char *gateway,
 					enum connman_ipconfig_type type,

--- a/src/connection.c
+++ b/src/connection.c
@@ -645,34 +645,36 @@ static int disable_gateway(struct gateway_data *data,
 	return 0;
 }
 
-static struct gateway_data *add_gateway(struct connman_service *service,
+static int add_gateway(struct connman_service *service,
 					int index, const char *gateway,
-					enum connman_ipconfig_type type)
+					enum connman_ipconfig_type type,
+					struct gateway_data **data)
 {
 	g_autofree struct gateway_data *temp_data = NULL;
 	struct gateway_config *config = NULL;
 	struct gateway_data *old;
+	int err = 0;
 
-	if (!service || index < 0 || !gateway || strlen(gateway) == 0)
-		return NULL;
+	if (!service || index < 0 || !gateway || strlen(gateway) == 0 || !data)
+		return -EINVAL;
 
 	switch (type) {
 	case CONNMAN_IPCONFIG_TYPE_IPV4:
 	case CONNMAN_IPCONFIG_TYPE_IPV6:
 		break;
 	default:
-		return NULL;
+		return -EINVAL;
 	}
 
 	temp_data = g_try_new0(struct gateway_data, 1);
 	if (!temp_data)
-		return NULL;
+		return -ENOMEM;
 
 	temp_data->index = index;
 
 	config = g_try_new0(struct gateway_config, 1);
 	if (!config)
-		return NULL;
+		return -ENOMEM;
 
 	config->gateway = g_strdup(gateway);
 	config->vpn_ip = NULL;
@@ -711,7 +713,9 @@ static struct gateway_data *add_gateway(struct connman_service *service,
 	connman_service_ref(temp_data->service);
 	g_hash_table_replace(gateway_hash, service, temp_data);
 
-	return g_steal_pointer(&temp_data);
+	*data = g_steal_pointer(&temp_data);
+
+	return err;
 }
 
 static void set_default_gateway(struct gateway_data *data,
@@ -1204,6 +1208,7 @@ int __connman_connection_gateway_add(struct connman_service *service,
 					connman_service_get_type(service);
 	int index;
 	g_autofree char *interface = NULL;
+	int err = 0;
 
 	DBG("service %p (%s) gateway %p (%s) type %d (%s) peer %p (%s)",
 		service, maybe_null(connman_service_get_identifier(service)),
@@ -1231,9 +1236,9 @@ int __connman_connection_gateway_add(struct connman_service *service,
 	DBG("service %p index %d gateway %s vpn ip %s type %d",
 		service, index, gateway, peer, type);
 
-	new_gateway = add_gateway(service, index, gateway, type);
-	if (!new_gateway)
-		return -EINVAL;
+	err = add_gateway(service, index, gateway, type, &new_gateway);
+	if (err < 0)
+		return err;
 
 	GATEWAY_DATA_DBG("new_gateway", new_gateway);
 
@@ -1308,7 +1313,8 @@ done:
 		__connman_service_ipconfig_indicate_state(service,
 						CONNMAN_SERVICE_STATE_READY,
 						CONNMAN_IPCONFIG_TYPE_IPV6);
-	return 0;
+
+	return err;
 }
 
 /**

--- a/src/connection.c
+++ b/src/connection.c
@@ -649,23 +649,30 @@ static struct gateway_data *add_gateway(struct connman_service *service,
 					int index, const char *gateway,
 					enum connman_ipconfig_type type)
 {
-	struct gateway_data *data, *old;
-	struct gateway_config *config;
+	g_autofree struct gateway_data *temp_data = NULL;
+	struct gateway_config *config = NULL;
+	struct gateway_data *old;
 
-	if (!gateway || strlen(gateway) == 0)
+	if (!service || index < 0 || !gateway || strlen(gateway) == 0)
 		return NULL;
 
-	data = g_try_new0(struct gateway_data, 1);
-	if (!data)
-		return NULL;
-
-	data->index = index;
-
-	config = g_try_new0(struct gateway_config, 1);
-	if (!config) {
-		g_free(data);
+	switch (type) {
+	case CONNMAN_IPCONFIG_TYPE_IPV4:
+	case CONNMAN_IPCONFIG_TYPE_IPV6:
+		break;
+	default:
 		return NULL;
 	}
+
+	temp_data = g_try_new0(struct gateway_data, 1);
+	if (!temp_data)
+		return NULL;
+
+	temp_data->index = index;
+
+	config = g_try_new0(struct gateway_config, 1);
+	if (!config)
+		return NULL;
 
 	config->gateway = g_strdup(gateway);
 	config->vpn_ip = NULL;
@@ -675,17 +682,11 @@ static struct gateway_data *add_gateway(struct connman_service *service,
 	config->active = false;
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
-		data->ipv4_config = config;
+		temp_data->ipv4_config = config;
 	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
-		data->ipv6_config = config;
-	else {
-		g_free(config->gateway);
-		g_free(config);
-		g_free(data);
-		return NULL;
-	}
+		temp_data->ipv6_config = config;
 
-	data->service = service;
+	temp_data->service = service;
 
 	/*
 	 * If the service is already in the hash, then we
@@ -699,18 +700,18 @@ static struct gateway_data *add_gateway(struct connman_service *service,
 			old->ipv4_config, old->ipv6_config);
 		disable_gateway(old, type);
 		if (type == CONNMAN_IPCONFIG_TYPE_IPV4) {
-			data->ipv6_config = old->ipv6_config;
+			temp_data->ipv6_config = old->ipv6_config;
 			old->ipv6_config = NULL;
 		} else if (type == CONNMAN_IPCONFIG_TYPE_IPV6) {
-			data->ipv4_config = old->ipv4_config;
+			temp_data->ipv4_config = old->ipv4_config;
 			old->ipv4_config = NULL;
 		}
 	}
 
-	connman_service_ref(data->service);
-	g_hash_table_replace(gateway_hash, service, data);
+	connman_service_ref(temp_data->service);
+	g_hash_table_replace(gateway_hash, service, temp_data);
 
-	return data;
+	return g_steal_pointer(&temp_data);
 }
 
 static void set_default_gateway(struct gateway_data *data,


### PR DESCRIPTION
This refactors the `add_gateway` function by:

1. Leverage early parameter checking, the `g_autofree` pointer decoration, and the `g_steal_pointer` macro to simplify exception handling.
2. Changes the function signature by migrating the return type to a double-pointer parameter and changing the return type to an `int` for error status. This allows passing the full range of failure errors to the caller and allows the caller to pass those errors directly along as their own return status.

In addition, this documents the function.