### PR TITLE
connection: Remove Unnecessary '__connman_service_get_index' Calls

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -1587,21 +1587,11 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 	struct gateway_data *data = NULL;
 	bool set_default4 = false, set_default6 = false;
         bool do_ipv4 = false, do_ipv6 = false;
-	int index;
-	g_autofree char *interface = NULL;
 	int err;
 
 	DBG("service %p (%s) type %d (%s)",
 		service, maybe_null(connman_service_get_identifier(service)),
 		type, __connman_ipconfig_type2string(type));
-
-	index = __connman_service_get_index(service);
-	if (index < 0)
-		return;
-
-	interface = connman_inet_ifname(index);
-
-	DBG("index %d (%s)", index, maybe_null(interface));
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
 		do_ipv4 = true;

--- a/src/connection.c
+++ b/src/connection.c
@@ -851,7 +851,6 @@ static int add_gateway(struct connman_service *service,
 static void set_default_gateway(struct gateway_data *data,
 				enum connman_ipconfig_type type)
 {
-	int index;
 	int status4 = 0, status6 = 0;
 	bool do_ipv4 = false, do_ipv6 = false;
 
@@ -897,11 +896,9 @@ static void set_default_gateway(struct gateway_data *data,
 		return;
 	}
 
-	index = __connman_service_get_index(data->service);
-
 	if (do_ipv4 && data->ipv4_config &&
 			is_ipv4_addr_any_str(data->ipv4_config->gateway)) {
-		if (connman_inet_set_gateway_interface(index) < 0)
+		if (connman_inet_set_gateway_interface(data->index) < 0)
 			return;
 		data->ipv4_config->active = true;
 		goto done;
@@ -909,7 +906,7 @@ static void set_default_gateway(struct gateway_data *data,
 
 	if (do_ipv6 && data->ipv6_config &&
 			is_ipv6_addr_any_str(data->ipv6_config->gateway)) {
-		if (connman_inet_set_ipv6_gateway_interface(index) < 0)
+		if (connman_inet_set_ipv6_gateway_interface(data->index) < 0)
 			return;
 		data->ipv6_config->active = true;
 		goto done;
@@ -917,11 +914,11 @@ static void set_default_gateway(struct gateway_data *data,
 
 	if (do_ipv6 && data->ipv6_config)
 		status6 = __connman_inet_add_default_to_table(RT_TABLE_MAIN,
-					index, data->ipv6_config->gateway);
+					data->index, data->ipv6_config->gateway);
 
 	if (do_ipv4 && data->ipv4_config)
 		status4 = __connman_inet_add_default_to_table(RT_TABLE_MAIN,
-					index, data->ipv4_config->gateway);
+					data->index, data->ipv4_config->gateway);
 
 	if (status4 < 0 || status6 < 0)
 		return;
@@ -933,7 +930,6 @@ done:
 static void unset_default_gateway(struct gateway_data *data,
 				enum connman_ipconfig_type type)
 {
-	int index;
 	bool do_ipv4 = false, do_ipv6 = false;
 
 	DBG("data %p type %d (%s)", data,
@@ -977,28 +973,26 @@ static void unset_default_gateway(struct gateway_data *data,
 		return;
 	}
 
-	index = __connman_service_get_index(data->service);
-
 	if (do_ipv4 && data->ipv4_config &&
 			is_ipv4_addr_any_str(data->ipv4_config->gateway)) {
-		connman_inet_clear_gateway_interface(index);
+		connman_inet_clear_gateway_interface(data->index);
 		data->ipv4_config->active = false;
 		return;
 	}
 
 	if (do_ipv6 && data->ipv6_config &&
 			is_ipv6_addr_any_str(data->ipv6_config->gateway)) {
-		connman_inet_clear_ipv6_gateway_interface(index);
+		connman_inet_clear_ipv6_gateway_interface(data->index);
 		data->ipv6_config->active = false;
 		return;
 	}
 
 	if (do_ipv6 && data->ipv6_config)
-		connman_inet_clear_ipv6_gateway_address(index,
+		connman_inet_clear_ipv6_gateway_address(data->index,
 						data->ipv6_config->gateway);
 
 	if (do_ipv4 && data->ipv4_config)
-		connman_inet_clear_gateway_address(index,
+		connman_inet_clear_gateway_address(data->index,
 						data->ipv4_config->gateway);
 }
 


### PR DESCRIPTION
This removed unnecessary calls to `__connman_service_get_index` that are either unused or are redundant.