### PR TITLE
connection: Explicitly handle 'CONNMAN_IPCONFIG_TYPE_ALL'

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -619,8 +619,10 @@ static int del_gateway_routes(struct gateway_data *data,
 		do_ipv4 = true;
 	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
 		do_ipv6 = true;
-	else
+	else if (type == CONNMAN_IPCONFIG_TYPE_ALL)
 		do_ipv4 = do_ipv6 = true;
+	else
+		return -EINVAL;
 
 	if (do_ipv4 && data->ipv4_config) {
 		if (data->ipv4_config->vpn) {
@@ -703,6 +705,12 @@ static int del_gateway_routes_if_active(struct gateway_data *data,
 {
 	bool active = false;
 
+	DBG("data %p type %d (%s)", data,
+		type, __connman_ipconfig_type2string(type));
+
+	if (!data || type == CONNMAN_IPCONFIG_TYPE_UNKNOWN)
+		return -EINVAL;
+
 	GATEWAY_DATA_DBG("data", data);
 
 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4) {
@@ -711,7 +719,7 @@ static int del_gateway_routes_if_active(struct gateway_data *data,
 	} else if (type == CONNMAN_IPCONFIG_TYPE_IPV6) {
 		if (data->ipv6_config)
 			active = data->ipv6_config->active;
-	} else
+	} else if (type == CONNMAN_IPCONFIG_TYPE_ALL)
 		active = true;
 
 	DBG("type %d active %d", type, active);
@@ -863,8 +871,10 @@ static void set_default_gateway(struct gateway_data *data,
 		do_ipv4 = true;
 	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
 		do_ipv6 = true;
-	else
+	else if (type == CONNMAN_IPCONFIG_TYPE_ALL)
 		do_ipv4 = do_ipv6 = true;
+	else
+		return;
 
 	if (do_ipv4 && data->ipv4_config &&
 					data->ipv4_config->vpn) {
@@ -941,11 +951,10 @@ static void unset_default_gateway(struct gateway_data *data,
 		do_ipv4 = true;
 	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
 		do_ipv6 = true;
-	else
+	else if (type == CONNMAN_IPCONFIG_TYPE_ALL)
 		do_ipv4 = do_ipv6 = true;
-
-	DBG("type %d gateway ipv4 %p ipv6 %p", type, data->ipv4_config,
-						data->ipv6_config);
+	else
+		return;
 
 	if (do_ipv4 && data->ipv4_config &&
 					data->ipv4_config->vpn) {
@@ -1591,8 +1600,10 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 		do_ipv4 = true;
 	else if (type == CONNMAN_IPCONFIG_TYPE_IPV6)
 		do_ipv6 = true;
-	else
+	else if (type == CONNMAN_IPCONFIG_TYPE_ALL)
 		do_ipv4 = do_ipv6 = true;
+	else
+		return;
 
     /* Delete any routes associated with this service's nameservers. */
 


### PR DESCRIPTION
At commit 89f70d225df6 ("ipconfig: Define unique value for `CONNMAN_IPCONFIG_TYPE_ALL`"), a unique enumertion value was provided for `CONNMAN_IPCONFIG_TYPE_ALL` to make it semantically different from `CONNMAN_IPCONFIG_TYPE_UNKNOWN`.

However, with that change, the connection module was never updated to explicitly treat `CONNMAN_IPCONFIG_TYPE_ALL` as a synonym for `CONNMAN_IPCONFIG_TYPE_IPV4` + `CONNMAN_IPCONFIG_TYPE_IPV6` and to treat `CONNMAN_IPCONFIG_TYPE_UNKNOWN` as an error.

This makes those changes, treating `CONNMAN_IPCONFIG_TYPE_ALL` as such a synonym and `CONNMAN_IPCONFIG_TYPE_UNKNOWN` as an error.