### PR TITLE
connection: Optimize Conditional '&&' Clauses in '__connman_connection_gateway_remove'

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -1632,13 +1632,11 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 
     /* If necessary, delete any VPN-related host routes. */
 
-	if (do_ipv4 && data->ipv4_config &&
-			data->ipv4_config->vpn && data->index >= 0)
+	if (set_default4 && data->index >= 0)
 		connman_inet_del_host_route(data->ipv4_config->vpn_phy_index,
 						data->ipv4_config->gateway);
 
-	if (do_ipv6 && data->ipv6_config &&
-			data->ipv6_config->vpn && data->index >= 0)
+	if (set_default6 && data->index >= 0)
 		connman_inet_del_ipv6_host_route(
 					data->ipv6_config->vpn_phy_index,
 						data->ipv6_config->gateway);

--- a/src/connection.c
+++ b/src/connection.c
@@ -1589,7 +1589,7 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 {
 	struct gateway_data *data = NULL;
 	bool set_default4 = false, set_default6 = false;
-        bool do_ipv4 = false, do_ipv6 = false;
+	bool do_ipv4 = false, do_ipv6 = false;
 	int err;
 
 	DBG("service %p (%s) type %d (%s)",

--- a/src/connection.c
+++ b/src/connection.c
@@ -1588,7 +1588,7 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 					enum connman_ipconfig_type type)
 {
 	struct gateway_data *data = NULL;
-	bool set_default4 = false, set_default6 = false;
+	bool is_vpn4 = false, is_vpn6 = false;
 	bool do_ipv4 = false, do_ipv6 = false;
 	int err;
 
@@ -1620,23 +1620,23 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 	GATEWAY_DATA_DBG("service_data", data);
 
 	if (do_ipv4 && data->ipv4_config)
-		set_default4 = data->ipv4_config->vpn;
+		is_vpn4 = data->ipv4_config->vpn;
 
 	if (do_ipv6 && data->ipv6_config)
-		set_default6 = data->ipv6_config->vpn;
+		is_vpn6 = data->ipv6_config->vpn;
 
 	DBG("ipv4 gateway %s ipv6 gateway %s vpn %d/%d",
 		data->ipv4_config ? data->ipv4_config->gateway : "<null>",
 		data->ipv6_config ? data->ipv6_config->gateway : "<null>",
-		set_default4, set_default6);
+		is_vpn4, is_vpn6);
 
     /* If necessary, delete any VPN-related host routes. */
 
-	if (set_default4 && data->index >= 0)
+	if (is_vpn4 && data->index >= 0)
 		connman_inet_del_host_route(data->ipv4_config->vpn_phy_index,
 						data->ipv4_config->gateway);
 
-	if (set_default6 && data->index >= 0)
+	if (is_vpn6 && data->index >= 0)
 		connman_inet_del_ipv6_host_route(
 					data->ipv6_config->vpn_phy_index,
 						data->ipv6_config->gateway);
@@ -1665,7 +1665,7 @@ void __connman_connection_gateway_remove(struct connman_service *service,
 	 * gateway delete notification.
 	 * We hit the same issue if remove_gateway() fails.
 	 */
-	if (set_default4 || set_default6 || err < 0) {
+	if (is_vpn4 || is_vpn6 || err < 0) {
 		data = find_default_gateway_data();
 
 		GATEWAY_DATA_DBG("default_data", data);


### PR DESCRIPTION
This optimizes the conditional `&&` clauses in `__connman_connection_gateway_remove` to take advantage of stored, local state in `set_default[46]` thereby avoiding redundant checks of `do_ipv[46]`, `data->ipv[46]_config`, and `data->ipv[46]_config->vpn`.
    
In `__connman_connection_gateway_remove`, local variables `set_default[46]` are set to reflect the state of `do_ipv[46] && data->ipv[46]_config` as well as that of `data->ipv[46]_config->vpn`, effectively forming a three-conditional `&&`.

Then, shortly thereafter, with no intervening mutations of `data`, `do_ipv[46]`, `data->ipv[46]_config`, and `data->ipv[46]_config->vpn` are checked again, along with `data->index >= 0`, in a
four-conditional `&&`. Since the first three of those checks are redundant and simply reflect the state of `set_default[46]`, three of those four conditional `&&` terms can simply be replaced with `set_default[46]`.