### PR TITLE
connection: Simplify '{un,}set_default_gateway' Flow

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -876,64 +876,57 @@ static void set_default_gateway(struct gateway_data *data,
 	else
 		return;
 
-	if (do_ipv4 && data->ipv4_config &&
-					data->ipv4_config->vpn) {
-		connman_inet_set_gateway_interface(data->index);
-		data->ipv4_config->active = true;
+	if (do_ipv4 && data->ipv4_config) {
+		if (data->ipv4_config->vpn) {
+			connman_inet_set_gateway_interface(data->index);
 
-		DBG("set %p index %d vpn %s index %d phy %s",
-			data, data->index, data->ipv4_config->vpn_ip,
-			data->ipv4_config->vpn_phy_index,
-			data->ipv4_config->vpn_phy_ip);
+			data->ipv4_config->active = true;
 
-		__connman_service_indicate_default(data->service);
+			DBG("set %p index %d vpn %s index %d phy %s",
+				data, data->index, data->ipv4_config->vpn_ip,
+				data->ipv4_config->vpn_phy_index,
+				data->ipv4_config->vpn_phy_ip);
+		} else if (is_ipv4_addr_any_str(data->ipv4_config->gateway)) {
+			if (connman_inet_set_gateway_interface(
+						data->index) < 0)
+				return;
 
-		return;
+			data->ipv4_config->active = true;
+		} else {
+			status4 = __connman_inet_add_default_to_table(
+						RT_TABLE_MAIN,
+						data->index,
+						data->ipv4_config->gateway);
+		}
 	}
 
-	if (do_ipv6 && data->ipv6_config &&
-					data->ipv6_config->vpn) {
-		connman_inet_set_ipv6_gateway_interface(data->index);
-		data->ipv6_config->active = true;
+	if (do_ipv6 && data->ipv6_config) {
+		if (data->ipv6_config->vpn) {
+			connman_inet_set_ipv6_gateway_interface(data->index);
 
-		DBG("set %p index %d vpn %s index %d phy %s",
-			data, data->index, data->ipv6_config->vpn_ip,
-			data->ipv6_config->vpn_phy_index,
-			data->ipv6_config->vpn_phy_ip);
+			data->ipv6_config->active = true;
 
-		__connman_service_indicate_default(data->service);
+			DBG("set %p index %d vpn %s index %d phy %s",
+				data, data->index, data->ipv6_config->vpn_ip,
+				data->ipv6_config->vpn_phy_index,
+				data->ipv6_config->vpn_phy_ip);
+		} else if (is_ipv6_addr_any_str(data->ipv6_config->gateway)) {
+			if (connman_inet_set_ipv6_gateway_interface(
+						data->index) < 0)
+				return;
 
-		return;
+			data->ipv6_config->active = true;
+		} else {
+			status6 = __connman_inet_add_default_to_table(
+						RT_TABLE_MAIN,
+						data->index,
+						data->ipv6_config->gateway);
+		}
 	}
-
-	if (do_ipv4 && data->ipv4_config &&
-			is_ipv4_addr_any_str(data->ipv4_config->gateway)) {
-		if (connman_inet_set_gateway_interface(data->index) < 0)
-			return;
-		data->ipv4_config->active = true;
-		goto done;
-	}
-
-	if (do_ipv6 && data->ipv6_config &&
-			is_ipv6_addr_any_str(data->ipv6_config->gateway)) {
-		if (connman_inet_set_ipv6_gateway_interface(data->index) < 0)
-			return;
-		data->ipv6_config->active = true;
-		goto done;
-	}
-
-	if (do_ipv6 && data->ipv6_config)
-		status6 = __connman_inet_add_default_to_table(RT_TABLE_MAIN,
-					data->index, data->ipv6_config->gateway);
-
-	if (do_ipv4 && data->ipv4_config)
-		status4 = __connman_inet_add_default_to_table(RT_TABLE_MAIN,
-					data->index, data->ipv4_config->gateway);
 
 	if (status4 < 0 || status6 < 0)
 		return;
 
-done:
 	__connman_service_indicate_default(data->service);
 }
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -949,53 +949,45 @@ static void unset_default_gateway(struct gateway_data *data,
 	else
 		return;
 
-	if (do_ipv4 && data->ipv4_config &&
-					data->ipv4_config->vpn) {
-		connman_inet_clear_gateway_interface(data->index);
-		data->ipv4_config->active = false;
+	if (do_ipv4 && data->ipv4_config) {
+		if (data->ipv4_config->vpn) {
+			connman_inet_clear_gateway_interface(data->index);
 
-		DBG("unset %p index %d vpn %s index %d phy %s",
-			data, data->index, data->ipv4_config->vpn_ip,
-			data->ipv4_config->vpn_phy_index,
-			data->ipv4_config->vpn_phy_ip);
+			data->ipv4_config->active = false;
 
-		return;
-	}
+			DBG("unset %p index %d vpn %s index %d phy %s",
+				data, data->index, data->ipv4_config->vpn_ip,
+				data->ipv4_config->vpn_phy_index,
+				data->ipv4_config->vpn_phy_ip);
+		} else if (is_ipv4_addr_any_str(data->ipv4_config->gateway)) {
+			connman_inet_clear_gateway_interface(data->index);
 
-	if (do_ipv6 && data->ipv6_config &&
-					data->ipv6_config->vpn) {
-		connman_inet_clear_ipv6_gateway_interface(data->index);
-		data->ipv6_config->active = false;
-
-		DBG("unset %p index %d vpn %s index %d phy %s",
-			data, data->index, data->ipv6_config->vpn_ip,
-			data->ipv6_config->vpn_phy_index,
-			data->ipv6_config->vpn_phy_ip);
-
-		return;
-	}
-
-	if (do_ipv4 && data->ipv4_config &&
-			is_ipv4_addr_any_str(data->ipv4_config->gateway)) {
-		connman_inet_clear_gateway_interface(data->index);
-		data->ipv4_config->active = false;
-		return;
-	}
-
-	if (do_ipv6 && data->ipv6_config &&
-			is_ipv6_addr_any_str(data->ipv6_config->gateway)) {
-		connman_inet_clear_ipv6_gateway_interface(data->index);
-		data->ipv6_config->active = false;
-		return;
-	}
-
-	if (do_ipv6 && data->ipv6_config)
-		connman_inet_clear_ipv6_gateway_address(data->index,
-						data->ipv6_config->gateway);
-
-	if (do_ipv4 && data->ipv4_config)
-		connman_inet_clear_gateway_address(data->index,
+			data->ipv4_config->active = false;
+		} else {
+			connman_inet_clear_gateway_address(data->index,
 						data->ipv4_config->gateway);
+		}
+	}
+
+	if (do_ipv6 && data->ipv6_config) {
+		if (data->ipv6_config->vpn) {
+			connman_inet_clear_ipv6_gateway_interface(data->index);
+
+			data->ipv6_config->active = false;
+
+			DBG("unset %p index %d vpn %s index %d phy %s",
+				data, data->index, data->ipv6_config->vpn_ip,
+				data->ipv6_config->vpn_phy_index,
+				data->ipv6_config->vpn_phy_ip);
+		} else if (is_ipv6_addr_any_str(data->ipv6_config->gateway)) {
+			connman_inet_clear_ipv6_gateway_interface(data->index);
+
+			data->ipv6_config->active = false;
+		} else {
+			connman_inet_clear_ipv6_gateway_address(data->index,
+						data->ipv6_config->gateway);
+		}
+	}
 }
 
 /**

--- a/src/connection.c
+++ b/src/connection.c
@@ -892,11 +892,17 @@ static void set_default_gateway(struct gateway_data *data,
 				return;
 
 			data->ipv4_config->active = true;
+
+			DBG("set %p index %d",
+				data, data->index);
 		} else {
 			status4 = __connman_inet_add_default_to_table(
 						RT_TABLE_MAIN,
 						data->index,
 						data->ipv4_config->gateway);
+
+			DBG("set %p index %d gateway %s",
+				data, data->index, data->ipv4_config->gateway);
 		}
 	}
 
@@ -916,13 +922,21 @@ static void set_default_gateway(struct gateway_data *data,
 				return;
 
 			data->ipv6_config->active = true;
+
+			DBG("set %p index %d",
+				data, data->index);
 		} else {
 			status6 = __connman_inet_add_default_to_table(
 						RT_TABLE_MAIN,
 						data->index,
 						data->ipv6_config->gateway);
+
+			DBG("set %p index %d gateway %s",
+				data, data->index, data->ipv4_config->gateway);
 		}
 	}
+
+	DBG("status4 %d status6 %d", status4, status6);
 
 	if (status4 < 0 || status6 < 0)
 		return;
@@ -963,9 +977,15 @@ static void unset_default_gateway(struct gateway_data *data,
 			connman_inet_clear_gateway_interface(data->index);
 
 			data->ipv4_config->active = false;
+
+			DBG("unset %p index %d",
+				data, data->index);
 		} else {
 			connman_inet_clear_gateway_address(data->index,
 						data->ipv4_config->gateway);
+
+			DBG("unset %p index %d gateway %s",
+				data, data->index, data->ipv4_config->gateway);
 		}
 	}
 
@@ -983,9 +1003,15 @@ static void unset_default_gateway(struct gateway_data *data,
 			connman_inet_clear_ipv6_gateway_interface(data->index);
 
 			data->ipv6_config->active = false;
+
+			DBG("unset %p index %d",
+				data, data->index);
 		} else {
 			connman_inet_clear_ipv6_gateway_address(data->index,
 						data->ipv6_config->gateway);
+
+			DBG("unset %p index %d gateway %s",
+				data, data->index, data->ipv4_config->gateway);
 		}
 	}
 }

--- a/src/connection.c
+++ b/src/connection.c
@@ -856,6 +856,35 @@ static int add_gateway(struct connman_service *service,
 	return err;
 }
 
+/**
+ *  @brief
+ *    Set, or assign, the gateway, or default route, for the specified
+ *    IP configuration type from the provided gateway data.
+ *
+ *  This attempts to set, or assign, the gateway, or default, route
+ *  for the specified IP configuration type from the provided gateway
+ *  data. The network interface and, by extension, the network service
+ *  with which the gateway is associated is determined by the @a index
+ *  field of @a data.
+ *
+ *  On success, the gateway configuration specific to @a type will
+ *  have its @a active field set to true and the gateway data network
+ *  service @a service will be signaled as the default via
+ *  #__connman_service_indicate_default.
+ *
+ *  @param[in,out]  data  A pointer to the mutable gateway data to
+ *                        assign as the default route.
+ *  @param[in]      type  The IP configuration type for which the
+ *                        gateway, or default router, configuration
+ *                        will be selected from @a data and used to
+ *                        set the default route.
+ *
+ *  @sa __connman_inet_add_default_to_table
+ *  @sa __connman_service_indicate_default
+ *  @sa connman_inet_set_gateway_interface
+ *  @sa connman_inet_set_ipv6_gateway_interface
+ *
+ */
 static void set_default_gateway(struct gateway_data *data,
 				enum connman_ipconfig_type type)
 {
@@ -944,6 +973,33 @@ static void set_default_gateway(struct gateway_data *data,
 	__connman_service_indicate_default(data->service);
 }
 
+/**
+ *  @brief
+ *    Unset the gateway, or default route, for the specified IP
+ *    configuration type from the provided gateway data.
+ *
+ *  This attempts to unset, or clear, the gateway, or default, route
+ *  for the specified IP configuration type from the provided gateway
+ *  data. The network interface and, by extension, the network service
+ *  with which the gateway is associated is determined by the @a index
+ *  field of @a data.
+ *
+ *  On success, the gateway configuration specific to @a type will
+ *  have its @a active field set to false.
+ *
+ *  @param[in,out]  data  A pointer to the mutable gateway data to
+ *                        clear as the default route.
+ *  @param[in]      type  The IP configuration type for which the
+ *                        gateway, or default router, configuration
+ *                        will be selected from @a data and used to
+ *                        unset the default route.
+ *
+ *  @sa connman_inet_clear_gateway_address
+ *  @sa connman_inet_clear_gateway_interface
+ *  @sa connman_inet_clear_ipv6_gateway_address
+ *  @sa connman_inet_clear_ipv6_gateway_interface
+ *
+ */
 static void unset_default_gateway(struct gateway_data *data,
 				enum connman_ipconfig_type type)
 {


### PR DESCRIPTION
Ostensibly over time, the logic of both `set_default_gateway` and `unset_default_gateway ` has become a bit complicated with early returns, gotos (in the case of `set_default_gateway `), repeated state checks, and
duplicated function calls (in the case of `set_default_gateway `).
    
However, amidst all of that, there is a simpler flow to surface. At its core, the functions are two identical outer conditional blocks: one for IPv4 and one for IPv6 and three inner conditional blocks within those: one for a VPN, one for a gateway with an any/unspecified address, and one for everything else. In the case of `set_default_gateway `, on success, a call to `__connman_service_indicate_default` is made; on failure, it is not.
    
This simplifies the flows of both functions accordingly, curtailing the number of early returns, eliminating all of the gotos, and reducing the repeated state checks and function calls to one through the use of those simplified conditional blocks.

Additionally, this adds `DBG` statements and documentation to both functions.