### PR TITLE
Added @file comment to 'src/connman.h'.

### DIFF
--- a/src/connman.h
+++ b/src/connman.h
@@ -19,6 +19,13 @@
  *
  */
 
+/**
+ *  @file
+ *    This file defines internal, non-public (that is, neither visible
+ *    nor consumable by plugins), cross-module interfaces.
+ *
+ */
+
 #include <stdbool.h>
 
 #include <glib.h>


### PR DESCRIPTION
While there is a very specific organization to the project headers and symbols, it is not immediately evident at first glance to the uninitiated.

The addition of this `@file` comment helps inform the uninitiated that 'connman.h' is reserved for private, cross-project interfaces which differentiates it from those publicly-consumable headers in 'include/'.