### PR TITLE
inet: Add '__connman_inet_rtnl_recv'.

### DIFF
--- a/src/connman.h
+++ b/src/connman.h
@@ -244,7 +244,8 @@ int __connman_inet_rtnl_send(struct __connman_inet_rtnl_handle *rtnl,
 {
 	return __connman_inet_rtnl_talk(rtnl, n, 0, NULL, NULL);
 }
-
+int __connman_inet_rtnl_recv(const struct __connman_inet_rtnl_handle *rtnl,
+			struct nlmsghdr **n);
 void __connman_inet_rtnl_close(struct __connman_inet_rtnl_handle *rth);
 int __connman_inet_rtnl_addattr_l(struct nlmsghdr *n, size_t max_length,
 			int type, const void *data, size_t data_length);

--- a/src/inet.c
+++ b/src/inet.c
@@ -2574,6 +2574,40 @@ static gboolean inet_rtnl_timeout_cb(gpointer user_data)
 	return FALSE;
 }
 
+/**
+ *  @brief
+ *    Receive and process a Linux Routing Netlink (rtnl) response
+ *    message.
+ *
+ *  This attempts to receive and process a Linux Routing Netlink
+ *  (rtnl) response message to a previous request send by
+ *  #__connman_inet_rtnl_send or #__connman_inet_rtnl_talk.
+ *
+ *  @param[in]      rtnl  A pointer to an immutable Connection
+ *                        Manager Routing Netlink (rtnl) session
+ *                        handle with which the response message will
+ *                        be received.
+ *  @param[in,out]  n     An optional pointer to storage for the
+ *                        Routing Netlink (rtnl) response message
+ *                        header which will be populated if a message
+ *                        is received and processed.
+ *
+ *  @retval  0            If successful.
+ *  @retval  -EINVAL      If @a rtnl is null.
+ *  @retval  -ECONNRESET  If zero bytes were read and/or the remote
+ *                        end of the Routing Netlink (rtnl) socket
+ *                        closed the connection.
+ *  @retval  -EBADMSG     If NLMSG_OK evaluates to false for the
+ *                        received Routing Netlink (rtnl) message or
+ *                        if the received message was of type
+ *                        NLMSG_NOOP or NLMSG_OVERRUN.
+ *
+ *  @sa __connman_inet_rtnl_open
+ *  @sa __connman_inet_rtnl_send
+ *  @sa __connman_inet_rtnl_talk
+ *  @sa __connman_inet_rtnl_close
+ *
+ */
 int __connman_inet_rtnl_recv(const struct __connman_inet_rtnl_handle *rtnl,
 	struct nlmsghdr **n)
 {


### PR DESCRIPTION
This refactors the private, file-scope interface `inet_rtnl_recv` into a separate semi-public, project-scope interface `__connman_inet_rtnl_recv`.

Currently, `inet_rtnl_recv` is intended to be used as a glib runloop helper in conjunction with `__connman_inet_rtnl_talk` for longer or multi-phase Routing Netlink (rtnl) interactions.

However, for short, concise open/send/recv/close Routing Netlink (rtnl) interactions in which there is a single request/response phase or the complexity of an asynchronous run loop interaction is not needed, there is not an appropriate _recv_ interface to peer with open/send/close.

With this change, the core of `inet_rtnl_recv` is factored out into that missing _recv_ interface, `__connman_inet_rtnl_recv` with `inet_rtnl_recv` invoking it.