### PR TITLE
inet: Add IPv{4,6} Host/Network Route Add/Delete with Metric / Priority Functions

### DIFF
--- a/include/inet.h
+++ b/include/inet.h
@@ -42,8 +42,26 @@ bool connman_inet_is_ifup(int index);
 
 int connman_inet_set_address(int index, struct connman_ipaddress *ipaddress);
 int connman_inet_clear_address(int index, struct connman_ipaddress *ipaddress);
+int connman_inet_add_host_route_with_metric(int index,
+					const char *host,
+					const char *gateway,
+					uint32_t metric);
+int connman_inet_del_host_route_with_metric(int index,
+					const char *host,
+					const char *gateway,
+					uint32_t metric);
 int connman_inet_add_host_route(int index, const char *host, const char *gateway);
 int connman_inet_del_host_route(int index, const char *host);
+int connman_inet_add_network_route_with_metric(int index,
+					const char *host,
+					const char *gateway,
+					uint8_t prefix_len,
+					uint32_t metric);
+int connman_inet_del_network_route_with_metric(int index,
+					const char *host,
+					const char *gateway,
+					uint8_t prefix_len,
+					uint32_t metric);
 int connman_inet_add_network_route(int index, const char *host, const char *gateway,
 					const char *netmask);
 int connman_inet_del_network_route(int index, const char *host);
@@ -56,9 +74,27 @@ int connman_inet_set_ipv6_address(int index,
 		struct connman_ipaddress *ipaddress);
 int connman_inet_clear_ipv6_address(int index,
 					struct connman_ipaddress *ipaddress);
+int connman_inet_add_ipv6_host_route_with_metric(int index,
+					const char *host,
+					const char *gateway,
+					uint32_t metric);
+int connman_inet_del_ipv6_host_route_with_metric(int index,
+					const char *host,
+					const char *gateway,
+					uint32_t metric);
 int connman_inet_add_ipv6_host_route(int index, const char *host,
 						const char *gateway);
 int connman_inet_del_ipv6_host_route(int index, const char *host);
+int connman_inet_del_ipv6_network_route_with_metric(int index,
+					const char *host,
+					const char *gateway,
+					uint8_t prefix_len,
+					uint32_t metric);
+int connman_inet_add_ipv6_network_route_with_metric(int index,
+					const char *host,
+					const char *gateway,
+					uint8_t prefix_len,
+					uint32_t metric);
 int connman_inet_add_ipv6_network_route(int index, const char *host,
 					const char *gateway,
 					unsigned char prefix_len);

--- a/include/inet.h
+++ b/include/inet.h
@@ -56,13 +56,14 @@ int connman_inet_set_ipv6_address(int index,
 		struct connman_ipaddress *ipaddress);
 int connman_inet_clear_ipv6_address(int index,
 					struct connman_ipaddress *ipaddress);
-int connman_inet_add_ipv6_network_route(int index, const char *host,
-					const char *gateway, unsigned char prefix_len);
 int connman_inet_add_ipv6_host_route(int index, const char *host,
 						const char *gateway);
+int connman_inet_del_ipv6_host_route(int index, const char *host);
+int connman_inet_add_ipv6_network_route(int index, const char *host,
+					const char *gateway,
+					unsigned char prefix_len);
 int connman_inet_del_ipv6_network_route(int index, const char *host,
 					unsigned char prefix_len);
-int connman_inet_del_ipv6_host_route(int index, const char *host);
 int connman_inet_clear_ipv6_gateway_address(int index, const char *gateway);
 int connman_inet_set_ipv6_gateway_interface(int index);
 int connman_inet_clear_ipv6_gateway_interface(int index);

--- a/src/inet.c
+++ b/src/inet.c
@@ -703,6 +703,67 @@ static int inet_mask_addr_data(size_t addr_len,
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Add or remove a host or network route.
+ *
+ *  This attempts to add or remove a host or network route to or from
+ *  the kernel using a Linux Route Netlink (rtnl) socket and protocol
+ *  with the specified attributes.
+ *
+ *  @note
+ *    The caller may provide the IPv4 or IPv6 @a host_or_network
+ *    address in masked (that is, 169.254.0.0/16) or unmasked
+ *    (169.254.75.191/16) form. The function will mask the address,
+ *    based on the prefix length, before modifying the route with it.
+ *
+ *  @param[in]  cmd              The Linux Route Netlink command to
+ *                               send. This is expected to be either
+ *                               RTM_NEWROUTE (add new route) or
+ *                               RTM_DELROUTE (delete existing route).
+ *  @param[in]  family           The address family associated with @a
+ *                               host_or_network and @a gateway, if
+ *                               present.
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host_or_network  A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 or IPv6 address, in text form,
+ *                               of the route host or network
+ *                               destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 or IPv6 address, in text
+ *                               form, of the route next hop gateway
+ *                               address.
+ *  @param[in]  prefixlen        The destination prefix length of the
+ *                               route.
+ *  @param[in]  table_id         The table to add/delete this route
+ *                               to/from.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host_or_network is null; if @a index is
+ *                    invalid; if the address family of @a family was
+ *                    not AF_INET (IPv4) or AF_INET6 (IPv6); if @a
+ *                    host_or_network or @a gateway, if present, do
+ *                    not contain a character string representing a
+ *                    valid network address in either the AF_INET or
+ *                    AF_INET6 family; or if the routing information
+ *                    to be added or deleted was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added or deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add or delete
+ *                    routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ */
 static int inet_modify_host_or_network_route(int cmd,
 					int family,
 					int index,

--- a/src/inet.c
+++ b/src/inet.c
@@ -651,6 +651,31 @@ static int inet_get_addr_data(int family,
 	return 0;
 }
 
+/**
+ *  @brief
+ *    Apply the specified prefix length to the specified binary
+ *    address data.
+ *
+ *  This attempts to apply the specified prefix length as a network /
+ *  prefix mask to the specified address data, in network (that is,
+ *  big endian) byte order, to generate a network address / prefix.
+ *
+ *  @param[in]      addr_len   The length, in bytes of the address
+ *                             pointed to by @a addr_data.
+ *  @param[in,out]  addr_data  A pointer to the mutable address data
+ *                             in binary form in network (that is,
+ *                             big endian) byte order to mask with @a
+ *                             prefixlen.
+ *  @param[in]      prefixlen  The prefix length to apply to @a
+ *                             addr_data as a mask to generate a
+ *                             network address / prefix.
+ *
+ *  @retval  0              If successful.
+ *  @retval  -EINVAL        If @a addr_len or @a addr_data are null
+ *                          or if the specified prefix length exceeds
+ *                          the address length.
+ *
+ */
 static int inet_mask_addr_data(size_t addr_len,
 			void *addr_data,
 			uint8_t prefixlen)

--- a/src/inet.c
+++ b/src/inet.c
@@ -597,6 +597,37 @@ static const char *rtnl_route_cmd2string(int cmd)
 	return "";
 }
 
+/**
+ *  @brief
+ *    Convert the specified address from text to binary form.
+ *
+ *  This attempts to converts the specified address in text form into
+ *  binary form in network (that is, big endian) byte order, according
+ *  to the specified address family.
+ *
+ *  @param[in]      family       The address family describing the
+ *                               address pointed to by @a addr_string.
+ *  @param[in]      addr_string  A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               address, in text form, to convert to
+ *                               binary form.
+ *  @param[in,out]  addr_data    A pointer to storage sufficiently
+ *                               large to hold @a addr_string
+ *                               converted into binary form. This will
+ *                               point to the converted binary address
+ *                               data on success.
+ *
+ *  @retval  0              If successful.
+ *  @retval  -EINVAL        If @a addr_string or @a addr_data are
+ *                          null or @a addr_string does not contain a
+ *                          character string representing a valid
+ *                          network address in @a family.
+ *  @retval  -EAFNOSUPPORT  If @ family does not contain a valid
+ *                          address family.
+ *
+ *  @sa inet_pton
+ *
+ */
 static int inet_get_addr_data(int family,
 			const char *addr_string,
 			void *addr_data)

--- a/src/inet.c
+++ b/src/inet.c
@@ -584,6 +584,18 @@ int connman_inet_clear_address(int index, struct connman_ipaddress *ipaddress)
 	return 0;
 }
 
+static const char *rtnl_route_cmd2string(int cmd)
+{
+	switch (cmd) {
+	case RTM_NEWROUTE:
+		return "add";
+	case RTM_DELROUTE:
+		return "del";
+	}
+
+	return "";
+}
+
 int connman_inet_add_host_route(int index, const char *host,
 				const char *gateway)
 {
@@ -3253,18 +3265,6 @@ int __connman_inet_add_fwmark_rule(uint32_t table_id, int family, uint32_t fwmar
 int __connman_inet_del_fwmark_rule(uint32_t table_id, int family, uint32_t fwmark)
 {
 	return iprule_modify(RTM_DELRULE, family, table_id, fwmark);
-}
-
-static const char *rtnl_route_cmd2string(int cmd)
-{
-	switch (cmd) {
-	case RTM_NEWROUTE:
-		return "add";
-	case RTM_DELROUTE:
-		return "del";
-	}
-
-	return "";
 }
 
 /**

--- a/src/inet.c
+++ b/src/inet.c
@@ -1309,6 +1309,44 @@ static int inet_modify_ipv6_host_route(int cmd,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add an IPv4 host route with a route metric/priority.
+ *
+ *  This attempts to add an IPv4 host route to the kernel using a
+ *  Linux Route Netlink (rtnl) socket and protocol with the specified
+ *  attributes and route metric/priority.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be added was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *
+ *  @sa inet_modify_ipv4_host_route
+ *
+ */
 int connman_inet_add_host_route_with_metric(int index,
 				const char *host,
 				const char *gateway,
@@ -1325,6 +1363,44 @@ int connman_inet_add_host_route_with_metric(int index,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Remove an IPv4 host route with a route metric/priority.
+ *
+ *  This attempts to remove an IPv4 host route from the kernel using a
+ *  Linux Route Netlink (rtnl) socket and protocol with the specified
+ *  attributes and route metric/priority.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be deleted was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to delete routes.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_ipv4_host_route
+ *
+ */
 int connman_inet_del_host_route_with_metric(int index,
 				const char *host,
 				const char *gateway,
@@ -1341,6 +1417,52 @@ int connman_inet_del_host_route_with_metric(int index,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add an IPv4 network route with a route metric/priority.
+ *
+ *  This attempts to add an IPv4 network route to the kernel using a
+ *  Linux Route Netlink (rtnl) socket and protocol with the specified
+ *  attributes and route metric/priority.
+ *
+ *  @note
+ *    The caller may provide the IPv4 @a network address in masked
+ *    (that is, 169.254.0.0/16) or unmasked (169.254.75.191/16)
+ *    form. The function will mask the address, based on the prefix
+ *    length, before modifying the route with it.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  network          A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 address, in text form, of the
+ *                               route network destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  prefixlen        The destination prefix length of the
+ *                               route.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a network is null; if @a index is invalid;
+ *                    if @a network or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be added was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *
+ *  @sa inet_modify_ipv4_network_route
+ *
+ */
 int connman_inet_add_network_route_with_metric(int index,
 				const char *network,
 				const char *gateway,
@@ -1359,6 +1481,52 @@ int connman_inet_add_network_route_with_metric(int index,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Remove an IPv4 network route with a route metric/priority.
+ *
+ *  This attempts to add an IPv4 network route from the kernel using a
+ *  Linux Route Netlink (rtnl) socket and protocol with the specified
+ *  attributes and route metric/priority.
+ *
+ *  @note
+ *    The caller may provide the IPv4 @a network address in masked
+ *    (that is, 169.254.0.0/16) or unmasked (169.254.75.191/16)
+ *    form. The function will mask the address, based on the prefix
+ *    length, before modifying the route with it.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  network          A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 address, in text form, of the
+ *                               route network destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  prefixlen        The destination prefix length of the
+ *                               route.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a network is null; if @a index is invalid;
+ *                    if @a network or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be deleted was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add routes.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_ipv4_network_route
+ *
+ */
 int connman_inet_del_network_route_with_metric(int index,
 				const char *network,
 				const char *gateway,
@@ -1530,6 +1698,44 @@ out:
 	return err;
 }
 
+/**
+ *  @brief
+ *    Add an IPv6 host route with a route metric/priority.
+ *
+ *  This attempts to add an IPv6 host route to the kernel using a
+ *  Linux Route Netlink (rtnl) socket and protocol with the specified
+ *  attributes and route metric/priority.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv6 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv6 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be added was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *
+ *  @sa inet_modify_ipv6_host_route
+ *
+ */
 int connman_inet_add_ipv6_host_route_with_metric(int index,
 				const char *host,
 				const char *gateway,
@@ -1546,6 +1752,44 @@ int connman_inet_add_ipv6_host_route_with_metric(int index,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Remove an IPv6 host route with a route metric/priority.
+ *
+ *  This attempts to remove an IPv6 host route from the kernel using a
+ *  Linux Route Netlink (rtnl) socket and protocol with the specified
+ *  attributes and route metric/priority.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv6 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv6 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be deleted was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to delete routes.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_ipv6_host_route
+ *
+ */
 int connman_inet_del_ipv6_host_route_with_metric(int index,
 				const char *host,
 				const char *gateway,
@@ -1562,6 +1806,53 @@ int connman_inet_del_ipv6_host_route_with_metric(int index,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add an IPv6 network route with a route metric/priority.
+ *
+ *  This attempts to add an IPv6 network route to the kernel using a
+ *  Linux Route Netlink (rtnl) socket and protocol with the specified
+ *  attributes and route metric/priority.
+ *
+ *  @note
+ *    The caller may provide the IPv6 @a network address in masked
+ *    (that is, 2601:647:5a00:1500::/56) or unmasked
+ *    (2601:647:5a00:15c1:230d:b2c9:c388:f96b/56) form. The function
+ *    will mask the address, based on the prefix length, before
+ *    modifying the route with it.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  network          A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv6 address, in text form, of the
+ *                               route network destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv6 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  prefixlen        The destination prefix length of the
+ *                               route.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a network is null; if @a index is invalid;
+ *                    if @a network or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be added was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *
+ *  @sa inet_modify_ipv6_network_route
+ *
+ */
 int connman_inet_add_ipv6_network_route_with_metric(int index,
 				const char *network,
 				const char *gateway,
@@ -1580,6 +1871,53 @@ int connman_inet_add_ipv6_network_route_with_metric(int index,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Remove an IPv6 network route with a route metric/priority.
+ *
+ *  This attempts to add an IPv6 network route from the kernel using a
+ *  Linux Route Netlink (rtnl) socket and protocol with the specified
+ *  attributes and route metric/priority.
+ *
+ *  @note
+ *    The caller may provide the IPv6 @a network address in masked
+ *    (that is, 2601:647:5a00:1500::/56) or unmasked
+ *    (2601:647:5a00:15c1:230d:b2c9:c388:f96b/56) form. The function
+ *    will mask the address, based on the prefix length, before
+ *    modifying the route with it.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  network          A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv6 address, in text form, of the
+ *                               route network destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv6 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  prefixlen        The destination prefix length of the
+ *                               route.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a network is null; if @a index is invalid;
+ *                    if @a network or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be deleted was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add routes.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_ipv4_network_route
+ *
+ */
 int connman_inet_del_ipv6_network_route_with_metric(int index,
 				const char *network,
 				const char *gateway,

--- a/src/inet.c
+++ b/src/inet.c
@@ -876,6 +876,68 @@ done:
 	return ret;
 }
 
+/**
+ *  @brief
+ *    Add or remove a host route.
+ *
+ *  This attempts to add or remove a host route to or from the kernel
+ *  using a Linux Route Netlink (rtnl) socket and protocol with the
+ *  specified attributes.
+ *
+ *  @note
+ *    The caller may provide the IPv4 or IPv6 @a host address in
+ *    masked (that is, 169.254.0.0/16) or unmasked (169.254.75.191/16)
+ *    form. The function will mask the address, based on the prefix
+ *    length, before modifying the route with it.
+ *
+ *  @param[in]  cmd              The Linux Route Netlink command to
+ *                               send. This is expected to be either
+ *                               RTM_NEWROUTE (add new route) or
+ *                               RTM_DELROUTE (delete existing route).
+ *  @param[in]  family           The address family associated with @a
+ *                               host and @a gateway, if present.
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 or IPv6 address, in text form,
+ *                               of the route host destination
+ *                               address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 or IPv6 address, in text
+ *                               form, of the route next hop gateway
+ *                               address.
+ *  @param[in]  prefixlen        The destination prefix length of the
+ *                               route.
+ *  @param[in]  table_id         The table to add/delete this route
+ *                               to/from.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    the address family of @a family was not AF_INET
+ *                    (IPv4) or AF_INET6 (IPv6); if @a host or @a
+ *                    gateway, if present, do not contain a character
+ *                    string representing a valid network address in
+ *                    either the AF_INET or AF_INET6 family; or if the
+ *                    routing information to be added or deleted was
+ *                    invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added or deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add or delete
+ *                    routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_host_or_network_route
+ *
+ */
 static int inet_modify_host_route(int cmd,
 					int family,
 					int index,
@@ -896,6 +958,68 @@ static int inet_modify_host_route(int cmd,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add or remove a network route.
+ *
+ *  This attempts to add or remove a network route to or from the
+ *  kernel using a Linux Route Netlink (rtnl) socket and protocol with
+ *  the specified attributes.
+ *
+ *  @note
+ *    The caller may provide the IPv4 or IPv6 @a network address in
+ *    masked (that is, 169.254.0.0/16) or unmasked (169.254.75.191/16)
+ *    form. The function will mask the address, based on the prefix
+ *    length, before modifying the route with it.
+ *
+ *  @param[in]  cmd              The Linux Route Netlink command to
+ *                               send. This is expected to be either
+ *                               RTM_NEWROUTE (add new route) or
+ *                               RTM_DELROUTE (delete existing route).
+ *  @param[in]  family           The address family associated with @a
+ *                               network and @a gateway, if present.
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  network          A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 or IPv6 address, in text form,
+ *                               of the route network destination
+ *                               address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 or IPv6 address, in text
+ *                               form, of the route next hop gateway
+ *                               address.
+ *  @param[in]  prefixlen        The destination prefix length of the
+ *                               route.
+ *  @param[in]  table_id         The table to add/delete this route
+ *                               to/from.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a network is null; if @a index is invalid;
+ *                    if the address family of @a family was not
+ *                    AF_INET (IPv4) or AF_INET6 (IPv6); if @a network
+ *                    or @a gateway, if present, do not contain a
+ *                    character string representing a valid network
+ *                    address in either the AF_INET or AF_INET6
+ *                    family; or if the routing information to be
+ *                    added or deleted was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added or deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add or delete
+ *                    routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_host_or_network_route
+ *
+ */
 static int inet_modify_network_route(int cmd,
 					int family,
 					int index,
@@ -916,6 +1040,58 @@ static int inet_modify_network_route(int cmd,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add or remove an IPv4 network route.
+ *
+ *  This attempts to add or remove an IPv4 network route to or from
+ *  the kernel using a Linux Route Netlink (rtnl) socket and protocol
+ *  with the specified attributes.
+ *
+ *  @note
+ *    The caller may provide the IPv4 @a network address in masked
+ *    (that is, 169.254.0.0/16) or unmasked (169.254.75.191/16)
+ *    form. The function will mask the address, based on the prefix
+ *    length, before modifying the route with it.
+ *
+ *  @param[in]  cmd              The Linux Route Netlink command to
+ *                               send. This is expected to be either
+ *                               RTM_NEWROUTE (add new route) or
+ *                               RTM_DELROUTE (delete existing route).
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  network          A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 address, in text form, of the
+ *                               route network destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a network is null; if @a index is invalid;
+ *                    if @a network or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be added or deleted was
+ *                    invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added or deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add or delete
+ *                    routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_network_route
+ *
+ */
 static int inet_modify_ipv4_network_route(int cmd,
 					int index,
 					const char *network,
@@ -934,6 +1110,59 @@ static int inet_modify_ipv4_network_route(int cmd,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add or remove an IPv6 network route.
+ *
+ *  This attempts to add or remove an IPv6 network route to or from
+ *  the kernel using a Linux Route Netlink (rtnl) socket and protocol
+ *  with the specified attributes.
+ *
+ *  @note
+ *    The caller may provide the IPv6 @a network address in masked
+ *    (that is, 2601:647:5a00:1500::/56) or unmasked
+ *    (2601:647:5a00:15c1:230d:b2c9:c388:f96b/56) form. The function
+ *    will mask the address, based on the prefix length, before
+ *    modifying the route with it.
+ *
+ *  @param[in]  cmd              The Linux Route Netlink command to
+ *                               send. This is expected to be either
+ *                               RTM_NEWROUTE (add new route) or
+ *                               RTM_DELROUTE (delete existing route).
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  network          A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv6 address, in text form, of the
+ *                               route network destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv6 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a network is null; if @a index is invalid;
+ *                    if @a network or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be added or deleted was
+ *                    invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added or deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add or delete
+ *                    routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_network_route
+ *
+ */
 static int inet_modify_ipv6_network_route(int cmd,
 					int index,
 					const char *network,
@@ -952,6 +1181,52 @@ static int inet_modify_ipv6_network_route(int cmd,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add or remove an IPv4 host route.
+ *
+ *  This attempts to add or remove an IPv4 host route to or from the
+ *  kernel using a Linux Route Netlink (rtnl) socket and protocol with
+ *  the specified attributes.
+ *
+ *  @param[in]  cmd              The Linux Route Netlink command to
+ *                               send. This is expected to be either
+ *                               RTM_NEWROUTE (add new route) or
+ *                               RTM_DELROUTE (delete existing route).
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be added or deleted was
+ *                    invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added or deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add or delete
+ *                    routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_host_route
+ *
+ */
 static int inet_modify_ipv4_host_route(int cmd,
 					int index,
 					const char *host,
@@ -970,6 +1245,52 @@ static int inet_modify_ipv4_host_route(int cmd,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add or remove an IPv6 host route.
+ *
+ *  This attempts to add or remove an IPv6 host route to or from the
+ *  kernel using a Linux Route Netlink (rtnl) socket and protocol with
+ *  the specified attributes.
+ *
+ *  @param[in]  cmd              The Linux Route Netlink command to
+ *                               send. This is expected to be either
+ *                               RTM_NEWROUTE (add new route) or
+ *                               RTM_DELROUTE (delete existing route).
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv6 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv6 address, in text form, of
+ *                               the route next hop gateway address.
+ *  @param[in]  metric           The routing priority metric for the
+ *                               route.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET6 family; or if
+ *                    the routing information to be added or deleted
+ *                    was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added or deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add or delete
+ *                    routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa inet_modify_host_route
+ *
+ */
 static int inet_modify_ipv6_host_route(int cmd,
 					int index,
 					const char *host,


### PR DESCRIPTION
This adds `connman_inet_{add,del}_{,ipv6_}{host,network}_route_with_metric` functions that provide the ability to add/delete an IPv4 or IPv6 host or network route with an explicit metric / priority.

As a convenience, the `connman_inet_{add,del}_{,ipv6_}network_route_with_metric` network route functions allow the caller to provide the IPv4 or IPv6 network address in masked (for example, 169.254.0.0/16) or unmasked (for example, 169.254.75.191/16) form. The function will mask the address, based on the provided prefix length, before modifying the route with it.