### PR TITLE
inet: Eliminate Dead Store in 'iproute_default_modify'.

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -4547,7 +4547,6 @@ static int iproute_default_modify(int cmd, uint32_t table_id, uint32_t metric,
 	rth.req.n.nlmsg_type = cmd;
 	rth.req.u.r.rt.rtm_family = family;
 	rth.req.u.r.rt.rtm_table = RT_TABLE_MAIN;
-	rth.req.u.r.rt.rtm_scope = RT_SCOPE_NOWHERE;
 	rth.req.u.r.rt.rtm_protocol = RTPROT_BOOT;
 	rth.req.u.r.rt.rtm_scope = RT_SCOPE_UNIVERSE;
 	rth.req.u.r.rt.rtm_type = RTN_UNICAST;


### PR DESCRIPTION
In `iproute_default_modify` there is a dead store to `rth.req.u.r.rt.rtm_scope` with `RT_SCOPE_NOWHERE` only to be overwritten two lines later with `RT_SCOPE_UNIVERSE` without an intervening read.

This eliminates the dead store of `RT_SCOPE_NOWHERE`.