### PR TITLE
service: Both Cancel and Stop Online Checks where  Appropriate

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -6014,7 +6014,10 @@ static void service_free(gpointer user_data)
 	__connman_notifier_service_remove(service);
 	service_schedule_removed(service);
 
+	cancel_online_check(service, CONNMAN_IPCONFIG_TYPE_ALL);
+
 	__connman_wispr_stop(service);
+
 	stats_stop(service);
 
 	service->path = NULL;
@@ -7192,6 +7195,8 @@ static int service_indicate_state(struct connman_service *service)
 		reply_pending(service, ECONNABORTED);
 
 		default_changed();
+
+		cancel_online_check(service, CONNMAN_IPCONFIG_TYPE_ALL);
 
 		__connman_wispr_stop(service);
 


### PR DESCRIPTION
This both cancels, via `cancel_online_check`, and stops, via `__connman_wispr_stop` online checks on service disconnect or free. The former terminates any in-flight or recurring check activity in _service.c_ and the latter terminates the same in _wispr.c_.

Failure to cancel as well as stop can lead to a use-after-free fault in one-shot or continuous online check mode when a latent online check reschedule timer fires after the service has been disconnected or deallocated.

To support these cancelations with a single `cancel_online_check` function call, support is added for passing `CONNMAN_IPCONFIG_TYPE_ALL` to `cancel_online_check` as the IP configuration type parameter.
