### PR TITLE
wispr/service: Add Per-service-unique WISPr Host Route Metric/Priority

### DIFF
--- a/src/connman.h
+++ b/src/connman.h
@@ -733,6 +733,8 @@ void __connman_service_remove_from_network(struct connman_network *network);
 void __connman_service_read_ip4config(struct connman_service *service);
 void __connman_service_read_ip6config(struct connman_service *service);
 
+int __connman_service_get_route_metric(const struct connman_service *service,
+				uint32_t *metric);
 struct connman_ipconfig *__connman_service_get_ip4config(
 				struct connman_service *service);
 struct connman_ipconfig *__connman_service_get_ip6config(

--- a/src/service.c
+++ b/src/service.c
@@ -6539,11 +6539,45 @@ __connman_service_get_network(struct connman_service *service)
 	return service->network;
 }
 
+/**
+ *  @brief
+ *    Return the current service count.
+ *
+ *  @returns
+ *    The current service count.
+ *
+ */
 static size_t service_get_count(void)
 {
 	return service_list ? g_list_length(service_list) : 0;
 }
 
+/**
+ *  @brief
+ *    Get the route metric/priority for the specified service.
+ *
+ *  This attempts to get the route metric/priority for the specified
+ *  service based on the current service and services state.
+ *
+ *  If the service is the default or if it is the only service, then
+ *  the metric is zero (0). Otherwise, a low-priority metric (metric >
+ *  0) unique to @a service and its underlying network interface is
+ *  computed and returned.
+ *
+ *  @param[in]      service  A pointer to the immutable service for
+ *                           which to get the route metric/priority.
+ *  @param[in,out]  metric   A pointer to storage for the route
+ *                           metric/priority, populated with the route
+ *                           metric/priority on success.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a service or @a metric are null.
+ *  @retval  -ENXIO   If the network interface index associated with
+ *                    @a service is invalid.
+ *
+ *  @sa connman_service_is_default
+ *
+ */
 int __connman_service_get_route_metric(const struct connman_service *service,
 				uint32_t *metric)
 {

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -164,6 +164,27 @@ static void connman_wispr_message_init(struct connman_wispr_message *msg)
 	msg->location_name = NULL;
 }
 
+/**
+ *  @brief
+ *    Deallocate resources associated with the specified WISPr host
+ *    route.
+ *
+ *  This attempts to deallocate resources, including host routes,
+ *  associated with the specified WISPr host route belonging to the
+ *  specified WISPr portal context.
+ *
+ *  @param[in]      wp_context  A pointer to the immutable WISPr
+ *                              portal context associated with @a
+ *                              route.
+ *  @param[in,out]  route       A pointer to the mutable WISPr host
+ *                              route structure for which to delete an
+ *                              associated host route and to
+ *                              deallocate any dynamically-allocated
+ *                              resources associated with it.
+ *
+ *  @sa wispr_route_request
+ *
+ */
 static void free_wispr_route(
 		const struct connman_wispr_portal_context *wp_context,
 		struct wispr_route *route)
@@ -205,6 +226,19 @@ free:
 	route->address = NULL;
 }
 
+/**
+ *  @brief
+ *    Deallocate host route resources associated with the specified
+ *    WISPr portal context.
+ *
+ *  This attempts to deallocate host route resources associated with
+ *  the specified WISPr specified WISPr portal context.
+ *
+ *  @param[in]      wp_context  A pointer to the mutable WISPr
+ *                              portal context for which to deallocate
+ *                              resources associated with host routes.
+ *
+ */
 static void free_wispr_routes(struct connman_wispr_portal_context *wp_context)
 {
 	while (wp_context->route_list) {

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1338,6 +1338,8 @@ int __connman_wispr_start(struct connman_service *service,
 	return 0;
 
 free_wp:
+	DBG("err %d wp_context %p", err, wp_context);
+
 	wp_context->cb(wp_context->service, wp_context->type, false, err);
 
 	g_hash_table_remove(wispr_portal_hash, GINT_TO_POINTER(index));

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1104,14 +1104,14 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context,
 	if (!interface)
 		return -EINVAL;
 
-	DBG("interface %s", interface);
-
 	if_index = connman_inet_ifindex(interface);
 	if (if_index < 0) {
 		DBG("Could not get ifindex");
 		err = -EINVAL;
 		goto done;
 	}
+
+	DBG("index %d (%s)", if_index, interface);
 
 	nameservers = connman_service_get_nameservers(wp_context->service);
 	if (!nameservers) {

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -50,9 +50,28 @@ enum connman_wispr_result {
 	CONNMAN_WISPR_RESULT_FAILED  = 3,
 };
 
+/**
+ *  State for host routes used for a WISPr request.
+ */
 struct wispr_route {
+	/**
+	 *	A pointer to a mutable, dynamically-allocated null-terminated
+	 *	C string containing the text-formatted address of the WISPr
+	 *	host.
+	 */
 	char *address;
+
+	/**
+	 *	The network interface index associated with the underlying
+	 *	network interface over which the WISPr request will sent and
+	 *	the reply received.
+	 */
 	int if_index;
+
+	/**
+	 *	The route metric/priority used for the host route created for
+	 *	the WISPr host.
+	 */
 	uint32_t metric;
 };
 

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -75,6 +75,10 @@ struct wispr_route {
 	uint32_t metric;
 };
 
+/**
+ *  Gateway configuration function pointers for IP configuration
+ *  type-specific route set/clear/add/delete operations.
+ */
 struct wispr_portal_context_route_ops {
 	int (*add_host_route_with_metric)(int index,
 		const char *host,
@@ -90,7 +94,13 @@ struct connman_wispr_portal_context {
 	int refcount;
 	struct connman_service *service;
 	enum connman_ipconfig_type type;
+
+	/**
+	 *	A pointer to immutable function pointers for route
+	 *	set/clear/add/delete operations.
+	 */
 	const struct wispr_portal_context_route_ops *ops;
+
 	__connman_wispr_cb_t cb;
 	struct connman_wispr_portal *wispr_portal;
 

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -708,6 +708,17 @@ static bool wispr_route_request(const char *address, int ai_family,
 		return false;
 	}
 
+	result = __connman_service_get_route_metric(wp_context->service,
+				&metric);
+	if (result < 0) {
+		DBG("failed to get metric for service %p (%s): %s (%d)",
+			wp_context->service,
+			connman_service_get_identifier(wp_context->service),
+			strerror(-result), result);
+
+		return false;
+	}
+
 	DBG("service %p (%s) metric %u",
 		wp_context->service,
 		connman_service_get_identifier(wp_context->service),

--- a/src/wispr.c
+++ b/src/wispr.c
@@ -1281,7 +1281,7 @@ int __connman_wispr_start(struct connman_service *service,
 	struct connman_wispr_portal *wispr_portal = NULL;
 	int index, err;
 
-	DBG("service %p (%s) type %d (%s) connect_timeout %ums callback %p",
+	DBG("service %p (%s) type %d (%s) connect_timeout %u ms callback %p",
 		service, connman_service_get_identifier(service),
 		type, __connman_ipconfig_type2string(type),
 		connect_timeout_ms, callback);


### PR DESCRIPTION
This add and leverages `__connman_service_get_route_metric` to select an appropriate service-specific route metric/priority when adding or deleting WISPr host routes.
    
This allows multiple such routes to coexist simultaneously, supporting "continuous" mode online checks in which one or more services may be conducting "online" WISPr-based Internet reachability checks as they move in and out of reachability success/failure.

`__connman_service_get_route_metric` is a non-public service interface, which attempts to get the route
metric/priority for the specified service based on the current service and services state.

If the service is the default or if it is the only service, then the metric is zero (0). Otherwise, a low-priority metric (metric > 0) unique to the service and its underlying network interface is computed and returned.
