### PR TITLE
Add Missing Gateway Parameter to Host Route Deletion Interfaces

### DIFF
--- a/include/inet.h
+++ b/include/inet.h
@@ -50,8 +50,12 @@ int connman_inet_del_host_route_with_metric(int index,
 					const char *host,
 					const char *gateway,
 					uint32_t metric);
-int connman_inet_add_host_route(int index, const char *host, const char *gateway);
-int connman_inet_del_host_route(int index, const char *host);
+int connman_inet_add_host_route(int index,
+					const char *host,
+					const char *gateway);
+int connman_inet_del_host_route(int index,
+					const char *host,
+					const char *gateway);
 int connman_inet_add_network_route_with_metric(int index,
 					const char *host,
 					const char *gateway,
@@ -82,9 +86,12 @@ int connman_inet_del_ipv6_host_route_with_metric(int index,
 					const char *host,
 					const char *gateway,
 					uint32_t metric);
-int connman_inet_add_ipv6_host_route(int index, const char *host,
-						const char *gateway);
-int connman_inet_del_ipv6_host_route(int index, const char *host);
+int connman_inet_add_ipv6_host_route(int index,
+					const char *host,
+					const char *gateway);
+int connman_inet_del_ipv6_host_route(int index,
+					const char *host,
+					const char *gateway);
 int connman_inet_del_ipv6_network_route_with_metric(int index,
 					const char *host,
 					const char *gateway,

--- a/src/connman.h
+++ b/src/connman.h
@@ -808,6 +808,7 @@ void __connman_service_nameserver_clear(struct connman_service *service);
 void __connman_service_nameserver_add_routes(const struct connman_service *service,
 						const char *gw);
 void __connman_service_nameserver_del_routes(const struct connman_service *service,
+					const char *gw,
 					enum connman_ipconfig_type type);
 void __connman_service_set_timeservers(struct connman_service *service,
 						char **timeservers);

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -401,9 +401,10 @@ struct gateway_config_ops {
 		uint32_t metric);
 
 	int (*add_host_route)(int index,
-		const char *gateway,
-		const char *host);
+		const char *host,
+		const char *gateway);
 	int (*del_host_route)(int index,
+		const char *host,
 		const char *gateway);
 };
 
@@ -1445,7 +1446,8 @@ static int del_gateway_routes(struct gateway_data *data,
 		} else {
 			data->ipv4_config->ops->del_host_route(
 						data->index,
-						data->ipv4_config->gateway);
+						data->ipv4_config->gateway,
+						NULL);
 
 			status4 = UNSET_DEFAULT_GATEWAY(data, type);
 
@@ -1462,7 +1464,8 @@ static int del_gateway_routes(struct gateway_data *data,
 		} else {
 			data->ipv6_config->ops->del_host_route(
 						data->index,
-						data->ipv6_config->gateway);
+						data->ipv6_config->gateway,
+						NULL);
 
 			status6 = UNSET_DEFAULT_GATEWAY(data, type);
 
@@ -3803,12 +3806,14 @@ void __connman_gateway_remove(struct connman_service *service,
 	if (is_vpn4 && data->index >= 0)
 		data->ipv4_config->ops->del_host_route(
 					data->ipv4_config->vpn_phy_index,
-					data->ipv4_config->gateway);
+					data->ipv4_config->gateway,
+					NULL);
 
 	if (is_vpn6 && data->index >= 0)
 		data->ipv6_config->ops->del_host_route(
 					data->ipv6_config->vpn_phy_index,
-					data->ipv6_config->gateway);
+					data->ipv6_config->gateway,
+					NULL);
 
 	/* Remove all active routes associated with this gateway data. */
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -3765,10 +3765,6 @@ void __connman_gateway_remove(struct connman_service *service,
 	else
 		return;
 
-    /* Delete any routes associated with this service's nameservers. */
-
-	__connman_service_nameserver_del_routes(service, type);
-
 	/*
 	 * If there is no hash table / map entry for this service, then
 	 * there are no gateways associated with it; simply return.
@@ -3778,6 +3774,18 @@ void __connman_gateway_remove(struct connman_service *service,
 		return;
 
 	GATEWAY_DATA_DBG("service_data", data);
+
+	/* Delete any routes associated with this service's nameservers. */
+
+	if (do_ipv4 && data->ipv4_config)
+		__connman_service_nameserver_del_routes(service,
+			data->ipv4_config->gateway,
+			type);
+
+	if (do_ipv6 && data->ipv6_config)
+		__connman_service_nameserver_del_routes(service,
+			data->ipv6_config->gateway,
+			type);
 
 	if (do_ipv4 && data->ipv4_config)
 		is_vpn4 = is_gateway_config_vpn(data->ipv4_config);

--- a/src/inet.c
+++ b/src/inet.c
@@ -1545,14 +1545,29 @@ int connman_inet_del_network_route_with_metric(int index,
 				metric);
 }
 
-int connman_inet_add_host_route(int index, const char *host,
+int connman_inet_add_host_route(int index,
+				const char *host,
 				const char *gateway)
 {
 	return connman_inet_add_network_route(index, host, gateway, NULL);
 }
 
-int connman_inet_del_host_route(int index, const char *host)
+int connman_inet_del_host_route(int index,
+				const char *host,
+				const char *gateway)
 {
+	/*
+	 * NOTE: The 'connman_inet_del_network_route' is deficient in that
+	 * it is missing the requisite 'gateway' parameter making it
+	 * symmetric with 'connman_inet_add_host_route' and
+	 * 'connman_inet_add_network_route'. Consequently, host route
+	 * deletion may fail.
+	 *
+	 * This, 'connman_inet_add_host_route', and
+	 * 'connman_inet_del_network_route' should probably be migrated to
+	 * the same RTNL-based call stack as
+	 * 'connman_inet_del_host_route_with_metric'.
+	 */
 	return connman_inet_del_network_route(index, host);
 }
 
@@ -1936,14 +1951,29 @@ int connman_inet_del_ipv6_network_route_with_metric(int index,
 				metric);
 }
 
-int connman_inet_add_ipv6_host_route(int index, const char *host,
-					const char *gateway)
+int connman_inet_add_ipv6_host_route(int index,
+				const char *host,
+				const char *gateway)
 {
 	return connman_inet_add_ipv6_network_route(index, host, gateway, 128);
 }
 
-int connman_inet_del_ipv6_host_route(int index, const char *host)
+int connman_inet_del_ipv6_host_route(int index,
+				const char *host,
+				const char *gateway)
 {
+	/*
+	 * NOTE: The 'connman_inet_del_ipv6_network_route' is deficient in
+	 * that it is missing the requisite 'gateway' parameter making it
+	 * symmetric with 'connman_inet_add_ipv6_host_route' and
+	 * 'connman_inet_add_ipv6_network_route'. Consequently, host route
+	 * deletion may fail.
+	 *
+	 * This, 'connman_inet_add_ipv6_host_route', and
+	 * 'connman_inet_del_ipv6_network_route' should probably be
+	 * migrated to the same RTNL-based call stack as
+	 * 'connman_inet_del_ipv6_host_route_with_metric'.
+	 */
 	return connman_inet_del_ipv6_network_route(index, host, 128);
 }
 

--- a/src/inet.c
+++ b/src/inet.c
@@ -1545,6 +1545,42 @@ int connman_inet_del_network_route_with_metric(int index,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add an IPv4 host route.
+ *
+ *  This attempts to add an IPv4 host route to the kernel with the
+ *  specified attributes.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 address, in text form, of
+ *                               the route next hop gateway address.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be added was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *
+ *  @sa connman_inet_del_host_route
+ *  @sa connman_inet_add_ipv6_host_route
+ *
+ */
 int connman_inet_add_host_route(int index,
 				const char *host,
 				const char *gateway)
@@ -1552,6 +1588,42 @@ int connman_inet_add_host_route(int index,
 	return connman_inet_add_network_route(index, host, gateway, NULL);
 }
 
+/**
+ *  @brief
+ *    Delete an IPv4 host route.
+ *
+ *  This attempts to delete an IPv4 host route to the kernel with the
+ *  specified attributes.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv4 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv4 address, in text form, of
+ *                               the route next hop gateway address.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be deleted was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to delete routes.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa connman_inet_add_host_route
+ *  @sa connman_inet_del_ipv6_host_route
+ *
+ */
 int connman_inet_del_host_route(int index,
 				const char *host,
 				const char *gateway)
@@ -1951,6 +2023,42 @@ int connman_inet_del_ipv6_network_route_with_metric(int index,
 				metric);
 }
 
+/**
+ *  @brief
+ *    Add an IPv6 host route.
+ *
+ *  This attempts to add an IPv6 host route to the kernel with the
+ *  specified attributes.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv6 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv6 address, in text form, of
+ *                               the route next hop gateway address.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be added was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    added was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to add routes.
+ *  @retval  -EEXIST  A request was made to add an existing routing
+ *                    entry.
+ *
+ *  @sa connman_inet_add_host_route
+ *  @sa connman_inet_del_ipv6_host_route
+ *
+ */
 int connman_inet_add_ipv6_host_route(int index,
 				const char *host,
 				const char *gateway)
@@ -1958,6 +2066,42 @@ int connman_inet_add_ipv6_host_route(int index,
 	return connman_inet_add_ipv6_network_route(index, host, gateway, 128);
 }
 
+/**
+ *  @brief
+ *    Delete an IPv6 host route.
+ *
+ *  This attempts to delete an IPv6 host route to the kernel with the
+ *  specified attributes.
+ *
+ *  @param[in]  index            The network interface index associated
+ *                               with the output network device for
+ *                               the route.
+ *  @param[in]  host             A pointer to an immutable null-
+ *                               terminated C string containing the
+ *                               IPv6 address, in text form, of the
+ *                               route host destination address.
+ *  @param[in]  gateway          An optional pointer to an immutable
+ *                               null-terminated C string containing
+ *                               the IPv6 address, in text form, of
+ *                               the route next hop gateway address.
+ *
+ *  @retval  0        If successful.
+ *  @retval  -EINVAL  If @a host is null; if @a index is invalid; if
+ *                    @a host or @a gateway, if present, do not
+ *                    contain a character string representing a valid
+ *                    network address in the AF_INET family; or if the
+ *                    routing information to be deleted was invalid.
+ *  @retval  -EFAULT  If the address to the routing information to be
+ *                    deleted was invalid.
+ *  @retval  -EPERM   If the current process does not have the
+ *                    credentials or capabilities to delete routes.
+ *  @retval  -ESRCH   A request was made to delete a non-existing
+ *                    routing entry.
+ *
+ *  @sa connman_inet_add_ipv6_host_route
+ *  @sa connman_inet_del_host_route
+ *
+ */
 int connman_inet_del_ipv6_host_route(int index,
 				const char *host,
 				const char *gateway)

--- a/src/service.c
+++ b/src/service.c
@@ -1348,6 +1348,9 @@ void __connman_service_nameserver_clear(struct connman_service *service)
 static void add_nameserver_route(int family, int index, const char *nameserver,
 				const char *gw)
 {
+	DBG("family %d index %d nameserver %s gw %s",
+		family, index, nameserver, gw);
+
 	switch (family) {
 	case AF_INET:
 		if (connman_inet_compare_subnet(index, nameserver))

--- a/src/service.c
+++ b/src/service.c
@@ -1376,14 +1376,27 @@ static void del_nameserver_route(int family, int index, const char *nameserver,
 
 	switch (family) {
 	case AF_INET:
-		if (type != CONNMAN_IPCONFIG_TYPE_IPV6)
-			connman_inet_del_host_route(index,
-						nameserver);
+		if (type != CONNMAN_IPCONFIG_TYPE_IPV4 &&
+			type != CONNMAN_IPCONFIG_TYPE_ALL)
+			break;
+
+		if (connman_inet_compare_subnet(index, nameserver))
+			break;
+
+		if (connman_inet_del_host_route(index, nameserver, gw) < 0)
+			/* For P-t-P link the above route del will fail */
+			connman_inet_del_host_route(index, nameserver, NULL);
 		break;
+
 	case AF_INET6:
-		if (type != CONNMAN_IPCONFIG_TYPE_IPV4)
-			connman_inet_del_ipv6_host_route(index,
-						nameserver);
+		if (type != CONNMAN_IPCONFIG_TYPE_IPV6 &&
+			type != CONNMAN_IPCONFIG_TYPE_ALL)
+			break;
+
+		if (connman_inet_del_ipv6_host_route(index, nameserver,
+								gw) < 0)
+			connman_inet_del_ipv6_host_route(index, nameserver,
+							NULL);
 		break;
 	}
 }

--- a/src/service.c
+++ b/src/service.c
@@ -1545,6 +1545,27 @@ static void nameserver_del_routes(int index, char **nameservers,
 	}
 }
 
+/**
+ *  @brief
+ *    Add IPv4 or IPv6 host routes for the domain name service (DNS)
+ *    servers associated with the specified service.
+ *
+ *  This attempts to add IPv4 or IPv6 host routes for both the
+ *  automatic and configured domain name service (DNS) servers
+ *  associated with the specified network service.
+ *
+ *  @param[in]  service      A pointer to the immutable network
+ *                           service for which to add DNS server host
+ *                           routes.
+ *  @param[in]  gw           A pointer to an immutable null-terminated
+ *                           C string containing the IPv4 or IPv6
+ *                           address, in text form, of the route next
+ *                           hop gateway address.
+ *
+ *  @sa __connman_service_nameserver_del_routes
+ *  @sa nameserver_add_routes
+ *
+ */
 void __connman_service_nameserver_add_routes(
 					const struct connman_service *service,
 					const char *gw)
@@ -1574,6 +1595,29 @@ void __connman_service_nameserver_add_routes(
 	}
 }
 
+/**
+ *  @brief
+ *    Delete IPv4 or IPv6 host routes for the domain name service (DNS)
+ *    servers associated with the specified service.
+ *
+ *  This attempts to delete IPv4 or IPv6 host routes for both the
+ *  automatic and configured domain name service (DNS) servers
+ *  associated with the specified network service.
+ *
+ *  @param[in]  service      A pointer to the immutable network
+ *                           service for which to delete DNS server
+ *                           host routes.
+ *  @param[in]  gw           A pointer to an immutable null-terminated
+ *                           C string containing the IPv4 or IPv6
+ *                           address, in text form, of the route next
+ *                           hop gateway address.
+ *  @param[in]  type         The IP configuration type for which to
+ *                           delete DNS server host routes.
+ *
+ *  @sa __connman_service_nameserver_del_routes
+ *  @sa nameserver_add_routes
+ *
+ */
 void __connman_service_nameserver_del_routes(
 					const struct connman_service *service,
 					const char *gw,

--- a/src/service.c
+++ b/src/service.c
@@ -1345,6 +1345,32 @@ void __connman_service_nameserver_clear(struct connman_service *service)
 	nameserver_add_all(service, CONNMAN_IPCONFIG_TYPE_ALL);
 }
 
+/**
+ *  @brief
+ *    Add an IPv4 or IPv6 host route for the specified domain name
+ *    service (DNS) server.
+ *
+ *  This attempts to add an IPv4 or IPv6 host route for the specified
+ *  domain name service (DNS) server with the specified attributes.
+ *
+ *  @param[in]  family      The address family describing the
+ *                          address pointed to by @a nameserver.
+ *  @param[in]  index       The network interface index associated
+ *                          with the output network device for
+ *                          the route.
+ *  @param[in]  nameserver  A pointer to an immutable null-terminated
+ *                          C string containing the IPv4 or IPv6
+ *                          address, in text form, of the route
+ *                          DNS server destination address.
+ *  @param[in]  gw          A pointer to an immutable null-terminated
+ *                          C string containing the IPv4 or IPv6
+ *                          address, in text form, of the route next
+ *                          hop gateway address.
+ *
+ *  @sa del_nameserver_route
+ *  @sa nameserver_add_routes
+ *
+ */
 static void add_nameserver_route(int family, int index, const char *nameserver,
 				const char *gw)
 {
@@ -1370,6 +1396,33 @@ static void add_nameserver_route(int family, int index, const char *nameserver,
 	}
 }
 
+/**
+ *  @brief
+ *    Delete an IPv4 or IPv6 host route for the specified domain name
+ *    service (DNS) server.
+ *
+ *  This attempts to delete an IPv4 or IPv6 host route for the
+ *  specified domain name service (DNS) server with the specified
+ *  attributes.
+ *
+ *  @param[in]  family      The address family describing the
+ *                          address pointed to by @a nameserver.
+ *  @param[in]  index       The network interface index associated
+ *                          with the output network device for
+ *                          the route.
+ *  @param[in]  nameserver  A pointer to an immutable null-terminated
+ *                          C string containing the IPv4 or IPv6
+ *                          address, in text form, of the route
+ *                          DNS server destination address.
+ *  @param[in]  gw          A pointer to an immutable null-terminated
+ *                          C string containing the IPv4 or IPv6
+ *                          address, in text form, of the route next
+ *                          hop gateway address.
+ *
+ *  @sa add_nameserver_route
+ *  @sa nameserver_del_routes
+ *
+ */
 static void del_nameserver_route(int family, int index, const char *nameserver,
 				const char *gw,
 				enum connman_ipconfig_type type)

--- a/src/service.c
+++ b/src/service.c
@@ -1367,6 +1367,27 @@ static void add_nameserver_route(int family, int index, char *nameserver,
 	}
 }
 
+static void del_nameserver_route(int family, int index, const char *nameserver,
+				const char *gw,
+				enum connman_ipconfig_type type)
+{
+	DBG("family %d index %d nameserver %s gw %s",
+		family, index, nameserver, gw);
+
+	switch (family) {
+	case AF_INET:
+		if (type != CONNMAN_IPCONFIG_TYPE_IPV6)
+			connman_inet_del_host_route(index,
+						nameserver);
+		break;
+	case AF_INET6:
+		if (type != CONNMAN_IPCONFIG_TYPE_IPV4)
+			connman_inet_del_ipv6_host_route(index,
+						nameserver);
+		break;
+	}
+}
+
 static void nameserver_add_routes(int index, char **nameservers,
 					const char *gw)
 {
@@ -1388,25 +1409,15 @@ static void nameserver_add_routes(int index, char **nameservers,
 static void nameserver_del_routes(int index, char **nameservers,
 				enum connman_ipconfig_type type)
 {
-	int i, family;
+	int i, ns_family;
 
 	for (i = 0; nameservers[i]; i++) {
-		family = connman_inet_check_ipaddress(nameservers[i]);
-		if (family < 0)
+		ns_family = connman_inet_check_ipaddress(nameservers[i]);
+		if (ns_family < 0)
 			continue;
 
-		switch (family) {
-		case AF_INET:
-			if (type != CONNMAN_IPCONFIG_TYPE_IPV6)
-				connman_inet_del_host_route(index,
-							nameservers[i]);
-			break;
-		case AF_INET6:
-			if (type != CONNMAN_IPCONFIG_TYPE_IPV4)
-				connman_inet_del_ipv6_host_route(index,
-							nameservers[i]);
-			break;
-		}
+		del_nameserver_route(ns_family, index, nameservers[i],
+			NULL, type);
 	}
 }
 

--- a/src/service.c
+++ b/src/service.c
@@ -1345,7 +1345,7 @@ void __connman_service_nameserver_clear(struct connman_service *service)
 	nameserver_add_all(service, CONNMAN_IPCONFIG_TYPE_ALL);
 }
 
-static void add_nameserver_route(int family, int index, char *nameserver,
+static void add_nameserver_route(int family, int index, const char *nameserver,
 				const char *gw)
 {
 	switch (family) {

--- a/src/service.c
+++ b/src/service.c
@@ -1457,6 +1457,31 @@ static void del_nameserver_route(int family, int index, const char *nameserver,
 	}
 }
 
+/**
+ *  @brief
+ *    Add IPv4 or IPv6 host routes for the specified domain name
+ *    service (DNS) servers.
+ *
+ *  This attempts to add IPv4 or IPv6 host routes for the specified
+ *  domain name service (DNS) servers with the specified attributes.
+ *
+ *  @param[in]  index        The network interface index associated
+ *                           with the output network device for
+ *                           the route.
+ *  @param[in]  nameservers  A pointer to a null-terminated array of
+ *                           mutable null-terminated C strings
+ *                           containing the IPv4 or IPv6 addresses, in
+ *                           text form, of the route DNS server
+ *                           destination addresses.
+ *  @param[in]  gw           A pointer to an immutable null-terminated
+ *                           C string containing the IPv4 or IPv6
+ *                           address, in text form, of the route next
+ *                           hop gateway address.
+ *
+ *  @sa add_nameserver_route
+ *  @sa nameserver_del_routes
+ *
+ */
 static void nameserver_add_routes(int index, char **nameservers,
 					const char *gw)
 {
@@ -1475,6 +1500,31 @@ static void nameserver_add_routes(int index, char **nameservers,
 	}
 }
 
+/**
+ *  @brief
+ *    Delete IPv4 or IPv6 host routes for the specified domain name
+ *    service (DNS) servers.
+ *
+ *  This attempts to delete IPv4 or IPv6 host routes for the specified
+ *  domain name service (DNS) servers with the specified attributes.
+ *
+ *  @param[in]  index        The network interface index associated
+ *                           with the output network device for
+ *                           the route.
+ *  @param[in]  nameservers  A pointer to a null-terminated array of
+ *                           mutable null-terminated C strings
+ *                           containing the IPv4 or IPv6 addresses, in
+ *                           text form, of the route DNS server
+ *                           destination addresses.
+ *  @param[in]  gw           A pointer to an immutable null-terminated
+ *                           C string containing the IPv4 or IPv6
+ *                           address, in text form, of the route next
+ *                           hop gateway address.
+ *
+ *  @sa del_nameserver_route
+ *  @sa nameserver_add_routes
+ *
+ */
 static void nameserver_del_routes(int index, char **nameservers,
 				const char *gw,
 				enum connman_ipconfig_type type)


### PR DESCRIPTION
Routing table manipulation, host routes among them, should be fundamentally symmetric. The routing table entry parameters used to add a route should be identical to those used to delete the same route. Otherwise, an `ESRCH` error may occur which, at present, are suppressed due to commit e03a01d3182d ("inet: Fix error handling when adding/removing routes") that is masking route deletion errors where this gateway parameter asymmetry is occurring.

This adds a previously-missing gateway address parameter to the `connman_inet_del_{,ipv6_}host_route` functions. In addition, call sites to `connman_inet_del_{,ipv6_}host_route` are updated to pass the gateway parameter.

In addition, in the process, this refactors `nameserver_del_routes` into a second, helper function
`del_nameserver_route` such that host route deletion is separated from DNS server iteration. This structure now mirrors that of `nameserver_add_routes` and `add_nameserver_route` since, again, route addition and deletion should be symmetric.

**NOTE:** This is only the first half of the necessary change. The second half is revising the actual implementation of `connman_inet_del_{,ipv6_}host_route` to take advantage of the newly-added gateway parameter. Implementation notes in each of `connman_inet_del_{,ipv6_}host_route` have been added toward that end.
