### PR TITLE
service: Qualify call to '__connman_timeserver_sync' with default check.

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -7773,8 +7773,25 @@ int __connman_service_ipconfig_indicate_state(struct connman_service *service,
 	if (!is_connected(old_state) && is_connected(new_state)) {
 		nameserver_add_all(service, type);
 
-		__connman_timeserver_sync(service,
-					CONNMAN_TIMESERVER_SYNC_REASON_STATE_UPDATE);
+		/*
+		 * Care must be taken here in a multi-technology and -service
+		 * environment. In such an environment, there may be a senior,
+		 * default service that is providing the network service for
+		 * time-of-day synchronization.
+		 *
+		 * Without an appropriate qualifier here, a junior,
+		 * non-default service may come in and usurp the senior,
+		 * default service and start trying to provide time-of-day
+		 * synchronization which is NOT what is desired.
+		 *
+		 * However, this qualifier should NOT be moved to the next
+		 * most outer block. Otherwise, name servers will not be added
+		 * to junior, non-default services and they will be unusable
+		 * from a DNS perspective.
+		 */
+		if (connman_service_is_default(service))
+			__connman_timeserver_sync(service,
+						CONNMAN_TIMESERVER_SYNC_REASON_STATE_UPDATE);
 	}
 
 	return service_indicate_state(service);


### PR DESCRIPTION
This addresses #116, by qualifying the call to `__connman_timeserver_sync` in `__connman_service_ipconfig_indicate_state` with a check against `connman_service_is_default`.

In a multi-technology and -service environment, there may be a senior, default service that is providing the network service for time-of-day synchronization.

Without the `connman_service_is_default` qualification, in a multi-technology and -service environment, as junior services transitions to the `ready` state, each of those service usurp the senior, default service and start trying to provide time-of-day synchronization which is **not** what is desired.

So, in a configuration with Ethernet, Wi-Fi, and Cellular in which they are preferred in that order and in which Ethernet is the default and becomes `ready` first, Ethernet will provide the network service for time-of-day synchronization. Then, once Wi-Fi becomes `ready`, it will usurp time-of-day synchronization from Ethernet. Similarly, when Cellular becomes `ready` it will usurp time-of-day synchronization from Wi-Fi. In all of those cases, time-of-day synchronization should have remained with Ethernet until such time as it was/is no longer the senior, default service.