### PR TITLE
Add Service Identifier to a Couple of 'DBG' Statements

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1937,7 +1937,9 @@ static void service_state_changed(struct connman_service *service,
 {
 	struct connman_service_info *info;
 
-	DBG("service %p state %d", service, state);
+	DBG("service %p (%s) state %d",
+		service, connman_service_get_identifier(service),
+		state);
 
 	info = g_hash_table_lookup(service_hash, service);
 

--- a/src/timeserver.c
+++ b/src/timeserver.c
@@ -417,7 +417,8 @@ static void ts_set_nameservers(const struct connman_service *service)
  */
 static void ts_reset(struct connman_service *service)
 {
-	DBG("service %p", service);
+	DBG("service %p (%s)",
+		service, connman_service_get_identifier(service));
 
 	if (!resolv)
 		return;


### PR DESCRIPTION
This adds the service identifier to the `DBG` statements in _timeserver.c_:`ts_reset` and _session.c_:`service_state_changed` to aid debugging in a multi-technology environment with "EnableOnlineToReadyTransition" asserted and for consistency with other `DBG` statements in other modules.
