### PR TITLE
Address Unhandled Gateway Route Lifecycle Events/Transitions

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -787,6 +787,20 @@ static bool is_gateway_config_type(const struct gateway_config *config,
 	return config->type == type;
 }
 
+static void gateway_config_set_active(struct gateway_config *config)
+{
+	gateway_config_state_set(config, CONNMAN_GATEWAY_CONFIG_STATE_ACTIVE);
+}
+
+static void gateway_config_set_inactive(struct gateway_config *config)
+{
+	gateway_config_state_set(config,
+		CONNMAN_GATEWAY_CONFIG_STATE_INACTIVE);
+
+	gateway_config_type_set(config,
+		CONNMAN_GATEWAY_CONFIG_TYPE_NONE);
+}
+
 /**
  *  @brief
  *    Conditionally log the specified gateway configuration.
@@ -3366,8 +3380,7 @@ static void gateway_rtnl_new(int index, const char *gateway)
 	 * and it is now acknowledged by the kernel. Consequently, mark it
 	 * as active.
 	 */
-	gateway_config_state_set(config,
-		CONNMAN_GATEWAY_CONFIG_STATE_ACTIVE);
+	gateway_config_set_active(config);
 
 	/*
 	 * It is possible that we have two default routes atm
@@ -3471,13 +3484,9 @@ static void gateway_rtnl_del(int index, const char *gateway)
 	if (config) {
 		GATEWAY_CONFIG_DBG("config", config);
 
-		if (is_gateway_config_state_removed(config)) {
-			gateway_config_state_set(config,
-				CONNMAN_GATEWAY_CONFIG_STATE_INACTIVE);
-
-			gateway_config_type_set(config,
-				CONNMAN_GATEWAY_CONFIG_TYPE_NONE);
-		} else {
+		if (is_gateway_config_state_removed(config))
+			gateway_config_set_inactive(config);
+		else {
 			DBG("ignoring gateway stale removed activation; "
 			"probably added before removed activation completed");
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -3102,9 +3102,11 @@ static int promote_default_gateway(struct gateway_data *data,
  *  existing gateway from the services-to-gateway data hash.
  *
  *  @param[in,out]  activated  A pointer to a mutable newly-activated
- *                             gateway.
+ *                             gateway from a Routing Netlink (rtnl)
+ *                             notification.
  *  @param[in,out]  existing   A pointer to a mutable existing
- *                             gateway.
+ *                             gateway from the services-to-gateway
+ *                             hash.
  *  @param[in]      type       The IP configuration type for which
  *                             gateway, or default router, is to be
  *                             yielded.
@@ -3200,9 +3202,11 @@ done:
  *  existing gateway from the services-to-gateway data hash.
  *
  *  @param[in,out]  activated  A pointer to a mutable newly-activated
- *                             gateway.
+ *                             gateway from a Routing Netlink (rtnl)
+ *                             notification.
  *  @param[in,out]  existing   A pointer to a mutable existing
- *                             gateway.
+ *                             gateway from the services-to-gateway
+ *                             hash.
  *
  *  @returns
  *    True if @a activated yielded the default gateway; otherwise,

--- a/src/inet.c
+++ b/src/inet.c
@@ -4748,6 +4748,12 @@ static int iproute_default_modify(int cmd, uint32_t table_id, uint32_t metric,
 		goto done;
 
 	ret = __connman_inet_rtnl_send(&rth, &rth.req.n);
+	if (ret < 0)
+		goto done;
+
+	ret = __connman_inet_rtnl_recv(&rth, NULL);
+	if (ret < 0)
+		goto done;
 
 done:
 	__connman_inet_rtnl_close(&rth);


### PR DESCRIPTION
There were a number of "escapes" or unhandled events and transitions that did not adhere to the documented gateway configuration lifecycle / state machine.

Failure to handle these was resulting in duplicate default routes, no default routes, and incorrect default route priorities for some services and their underlying network interfaces.

These "escapes" were handled in three primary ways with this patch series:

1. Leveraging `__connman_inet_rtnl_recv` in `iproute_default_modify`.
2. Leveraging `-ESRCH` returned by `iproute_default_modify`.
3. Adding explicit conditional cases for the "escapes" not otherwise covered by (1) and (2).
