### PR TITLE
service: Improve Logging and Event Visibility at the Info Level

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -2195,9 +2195,17 @@ static void cancel_online_check(struct connman_service *service,
 static bool online_check_is_enabled_check(
 		const struct connman_service *service)
 {
+	g_autofree char *interface = NULL;
+
 	if (!__connman_service_is_online_check_enabled()) {
-		connman_info("Online check disabled. "
-			"Default service remains in READY state.");
+		interface = connman_service_get_interface(service);
+
+		connman_info("Online check disabled; "
+			"interface %s [ %s ] remains in %s state.",
+			interface,
+			__connman_service_type2string(service->type),
+			state2string(CONNMAN_SERVICE_STATE_READY));
+
 		return false;
 	}
 


### PR DESCRIPTION
This improves service logging and event visibility at the info level by making the following additions and changes:

1. Make log output of `online_check_is_enabled_check` consistent, resulting in log entries similar to `Online check disabled; interface wlan0 [ wifi ] remains in ready state.`.
2. Log service default, error, and state changes, resulting in log entries similar to:

```
 Interface eth0 [ ethernet ] is the default
 Interface wlan0 [ wifi ] error "online-check-failed"
 Interface wwan0 [ cellular ] state is online
```