### PR TITLE
doc: Correct 'OnlineCheck{Initial,Max}Interval' units.

### DIFF
--- a/doc/connman.conf.5.in
+++ b/doc/connman.conf.5.in
@@ -183,7 +183,7 @@ default value is zero ('0') which indicates that no explicit
 connection timeout will be used, leaving the timeout to the underlying
 operating system and network stack.
 .TP
-.BI OnlineCheckInitialInterval= secs, OnlineCheckMaxInterval= secs
+.BI OnlineCheckInitialInterval= interval, OnlineCheckMaxInterval= interval
 Range of intervals between two online check requests.
 Please refer to the README for more detailed information.
 Default values are 1 and 12 respectively.


### PR DESCRIPTION
This corrects the `OnlineCheck{Initial,Max}Interval` units from _secs_ to _interval_.

Ultimately, in conjunction with a function associated with `OnlineCheckIntervalStyle`, `OnlineCheck{Initial,Max}Interval` can be translated into seconds; however, the values themselves are simply unit-less interval indices.