### PR TITLE
ofono: Make the oFono Plugin Modem Interface Order Tolerant

### DIFF
--- a/plugins/ofono.c
+++ b/plugins/ofono.c
@@ -1189,12 +1189,15 @@ static int add_cm_context(struct modem_data *modem, const char *context_path,
 	struct network_context *context = NULL;
 	dbus_bool_t active = FALSE;
 	const char *ip_protocol = NULL;
+	int err = 0;
 
 	DBG("%s context path %s", modem->path, context_path);
 
 	context = network_context_alloc(context_path);
-	if (!context)
-		return -ENOMEM;
+	if (!context) {
+		err = -ENOMEM;
+		goto done;
+	}
 
 	while (dbus_message_iter_get_arg_type(dict) == DBUS_TYPE_DICT_ENTRY) {
 		DBusMessageIter entry, value;
@@ -1246,7 +1249,8 @@ static int add_cm_context(struct modem_data *modem, const char *context_path,
 
 	if (g_strcmp0(context_type, "internet") != 0) {
 		network_context_unref(context);
-		return -EINVAL;
+		err = -EINVAL;
+		goto done;
 	}
 
 	if (ip_protocol)
@@ -1261,7 +1265,10 @@ static int add_cm_context(struct modem_data *modem, const char *context_path,
 	    has_interface(modem->interfaces, OFONO_API_NETREG))
 		add_network(modem, context);
 
-	return 0;
+done:
+	DBG("err %d", err);
+
+	return err;
 }
 
 static void remove_cm_context(struct modem_data *modem,

--- a/plugins/ofono.c
+++ b/plugins/ofono.c
@@ -167,6 +167,9 @@ struct modem_data {
 	DBusPendingCall *call_get_contexts;
 };
 
+static int cm_get_contexts(struct modem_data *modem);
+static int cm_get_properties(struct modem_data *modem);
+
 static const char *api2string(enum ofono_api api)
 {
 	switch (api) {
@@ -1037,6 +1040,27 @@ static bool try_create_device(struct modem_data *modem)
 
 	modem->device = device;
 	connman_device_set_powered(modem->device, modem->online);
+
+	/*
+	 * The order in which the LTE and Connection Manager interfaces
+	 * arrive may not always be the same.
+	 *
+	 * If the latter arrived before the former and a modem device was
+	 * successfully created, this represents a secondary opportunity
+	 * to get Connection Manager properties and contexts, both
+	 * essential to successfully creating a Connection Manager
+	 * Cellular network and service.
+	 *
+	 * The primary opportunity would have been with api_added in
+	 * modem_update_interfaces; however, that would have been skipped
+	 * since the LTE interface did not yet exist in such a scenario
+	 * and this call would exit early due to the LTE_CAPABLE and
+	 * OFONO_API_LTE conditional checks above.
+	 */
+	if (has_interface(modem->interfaces, OFONO_API_CM)) {
+		cm_get_properties(modem);
+		cm_get_contexts(modem);
+	}
 
 	return true;
 }

--- a/plugins/ofono.c
+++ b/plugins/ofono.c
@@ -289,7 +289,7 @@ static void set_connected(struct modem_data *modem,
 	char *nameservers;
 	int index;
 
-	DBG("%s", modem->path);
+	DBG("modem %p path %s context %p path %s", modem, modem->path, context, context->path);
 
 	index = context->index;
 
@@ -300,9 +300,13 @@ static void set_connected(struct modem_data *modem,
 		return;
 	}
 
+	DBG("context->network %p", context->network);
+
 	service = connman_service_lookup_from_network(context->network);
 	if (!service)
 		return;
+
+	DBG("service %p", service);
 
 	connman_service_create_ip4config(service, index);
 	connman_network_set_ipv4_method(context->network, method);
@@ -1054,7 +1058,9 @@ static void add_network(struct modem_data *modem,
 {
 	const char *group;
 
-	DBG("%s", modem->path);
+	DBG("modem %p path %s context %p path %s network %p",
+		modem, modem->path,
+		context, context->path, context->network);
 
 	if (context->network)
 		return;
@@ -1324,9 +1330,13 @@ static gboolean context_changed(DBusConnection *conn,
 	if (!modem)
 		return TRUE;
 
+	DBG("modem %p", modem);
+
 	context = get_context_with_path(modem->context_list, context_path);
 	if (!context)
 		return TRUE;
+
+	DBG("context %p", context);
 
 	if (!dbus_message_iter_init(message, &iter))
 		return TRUE;
@@ -1399,6 +1409,8 @@ static gboolean context_changed(DBusConnection *conn,
 		const char *ip_protocol;
 
 		dbus_message_iter_get_basic(&value, &ip_protocol);
+
+		DBG("%s Protocol %s", modem->path, ip_protocol);
 
 		set_context_ipconfig(context, ip_protocol);
 	}
@@ -1553,7 +1565,12 @@ static gboolean cm_context_removed(DBusConnection *conn,
 	if (!modem)
 		return TRUE;
 
+	DBG("modem %p", modem);
+
 	context = get_context_with_path(modem->context_list, context_path);
+
+	DBG("context %p", context);
+
 	remove_cm_context(modem, context);
 
 	return TRUE;
@@ -1805,9 +1822,13 @@ static gboolean cm_changed(DBusConnection *conn, DBusMessage *message,
 	DBusMessageIter iter, value;
 	const char *key;
 
+	DBG("");
+
 	modem = g_hash_table_lookup(modem_hash, path);
 	if (!modem)
 		return TRUE;
+
+	DBG("modem %p modem->ignore %u", modem, modem->ignore);
 
 	if (modem->ignore)
 		return TRUE;
@@ -1882,6 +1903,8 @@ static gboolean sim_changed(DBusConnection *conn, DBusMessage *message,
 	if (!modem)
 		return TRUE;
 
+	DBG("modem %p modem->ignore %u", modem, modem->ignore);
+
 	if (modem->ignore)
 		return TRUE;
 
@@ -1892,6 +1915,8 @@ static gboolean sim_changed(DBusConnection *conn, DBusMessage *message,
 
 	dbus_message_iter_next(&iter);
 	dbus_message_iter_recurse(&iter, &value);
+
+	DBG("key %s", key);
 
 	if (g_str_equal(key, "SubscriberIdentity")) {
 		sim_update_imsi(modem, &value);
@@ -1976,9 +2001,10 @@ static void modem_update_interfaces(struct modem_data *modem,
 				uint8_t old_ifaces,
 				uint8_t new_ifaces)
 {
-	DBG("%s", modem->path);
+	DBG("modem %p path %s", modem, modem->path);
 
 	if (api_added(old_ifaces, new_ifaces, OFONO_API_SIM)) {
+		DBG("modem->imsi %p modem->set_powered %u", modem->imsi, modem->set_powered);
 		if (!modem->imsi &&
 				!modem->set_powered) {
 			/*
@@ -1990,6 +2016,7 @@ static void modem_update_interfaces(struct modem_data *modem,
 	}
 
 	if (api_added(old_ifaces, new_ifaces, OFONO_API_CM)) {
+		DBG("modem->device %p", modem->device);
 		if (modem->device) {
 			cm_get_properties(modem);
 			cm_get_contexts(modem);

--- a/plugins/ofono.c
+++ b/plugins/ofono.c
@@ -1333,6 +1333,12 @@ static gboolean context_changed(DBusConnection *conn,
 
 	DBG("context_path %s", context_path);
 
+	/*
+	 * If there is no modem in the context hash for the associated
+	 * context path, then there is nothing to do at the moment as
+	 * the context must first be added before we can process changes
+	 * to it.
+	 */
 	modem = g_hash_table_lookup(context_hash, context_path);
 	if (!modem)
 		return TRUE;


### PR DESCRIPTION
This addresses and closes #135 by providing a secondary opportunity to send D-Bus request to get _Connection Manager_ interface properties and contexts at the successful closure of `try_create_device` since the primary opportunity in `modem_update_interfaces` is missed in the following test case:

```
# connmanctl disable cellular
# /etc/init.d/connman stop
# /etc/init.d/ofono stop
# rm -rf /var/lib/ofono/*
# rm -rf /var/lib/connman/cellular*
# /etc/init.d/ofono start
# /etc/init.d/connman start
# connmanctl enable cellular
```

At this point, ofonod will create a fully-provisioned and -functional Cellular service, with both IPv4 and IPv6 Cellular network contexts. However, connmand has no network and no service associated with it so, so any Connection Manager client observing the Cellular service state will observe it failing, on timeout.

In this use case, the ordering of the oFono `lte` (_Long-term Evolution_) and `cm` (_Connection Manager_) modem interfaces shared between `ofonod` and `connmand` is different from what they normally are in the case where a Cellular connection has already been established. Consequently, when the `cm` interface state change notification addition arrives, the connman device has not yet been created because in `modem_update_interfaces` executing
`cm_get_properties` and `cm_get_contexts` is dependent on the presence of `modem->device`:

```c
    if (api_added(old_ifaces, new_ifaces, OFONO_API_CM)) {
        if (modem->device) {
            cm_get_properties(modem);
            cm_get_contexts(modem);
        }
    }
```

Unfortunately, that does not and cannot happen until the `lte` modem interface is added because `try_create_device` has these conditionals:

```c
    if ((modem->capabilities & LTE_CAPABLE) &&
            !has_interface(modem->interfaces, OFONO_API_LTE))
        return false;
```

and the `lte` interface is added only moments later (rather than moments earlier as is normal outside this use case), but too late nonetheless. So, the ofono plugin will never get `cm` interface properties or Cellular network contexts.

With this change, each call to `try_create_device` now has an opportunity to check if the `cm` interface has been added and, if it has, to request `cm` properties and contexts.