### PR TITLE
Fix '__connman_connection_gateway_add' VPN Regression Introduced in Commit 823d5a2a8cc4

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -3704,10 +3704,10 @@ int __connman_gateway_add(struct connman_service *service,
 					is_gateway_config_vpn(
 						new_gateway->ipv4_config);
 
-		is_vpn6 = do_ipv4 &&
-					new_gateway->ipv4_config &&
+		is_vpn6 = do_ipv6 &&
+					new_gateway->ipv6_config &&
 					is_gateway_config_vpn(
-						new_gateway->ipv4_config);
+						new_gateway->ipv6_config);
 
 	} else {
 		if (do_ipv4 && new_gateway->ipv4_config)


### PR DESCRIPTION
This fully addresses and closes #137 by fixing a regression introduced in [823d5a2a8cc4](https://git.kernel.org/pub/scm/network/connman/connman.git/commit/?id=823d5a2a8cc4) ("connection: Refactor
`__connman_connection_gateway_add`") in which the `is_vpn6` calculation was inadvertently copied-and-pasted from the peer `is_vpn4` calculation by correctly using the associated IPv6-related `new_gateway` data members.
    
This stops WireGuard and other VPN-related plugins from faulting on start-up.